### PR TITLE
Get media URL from new end point.

### DIFF
--- a/data.py
+++ b/data.py
@@ -137,8 +137,8 @@ def get_episodes(series_id, season_id):
 
 def get_media_url(video_id, bitrate):
   bitrate = 4 if bitrate > 4 else bitrate
-  url = "http://nrk.no/serum/api/video/%s" % video_id
-  url = _get_cached_json(url, 'mediaURL')
+  url = "http://v7.psapi.nrk.no/mediaelement/%s" % video_id
+  url = _get_cached_json(url, 'mediaUrl')
   url = url.replace('/z/', '/i/', 1)
   url = url.rsplit('/', 1)[0]
   url = url + '/index_%s_av.m3u8' % bitrate


### PR DESCRIPTION
Hi!

Thanks a lot for your work letting XBMC users enjoy NRK! As you probably already have noticed some changes happened to the old API during the past week. I meant to let you know beforehand, but due to internal movement we had to release it a bit earlier. Anyways I've created a tiny PR illustrating the change. We are letting the endpoint http://nrk.no/serum/api/video/{id} live for now but it's only a re-direct to the preferred http://v7.psapi.nrk.no/mediaelement/{id} endpoint.
