### PR TITLE
Add .gitattributes to prevent .gitignore getting inside release zips.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
new git tags can be exported using:
git archive --prefix=plugin.video.nrk/ --output plugin.video.nrk-x.y.z.zip vx.y.z
