### PR TITLE
Updated from v7 to v8 of nrk api

### DIFF
--- a/nrktv.py
+++ b/nrktv.py
@@ -163,7 +163,7 @@ def get_episodes(series_id, season_id):
 
 
 def get_media_url(video_id):
-    url = "http://v7.psapi.nrk.no/mediaelement/%s" % video_id
+    url = "http://v8.psapi.nrk.no/mediaelement/%s" % video_id
     return session.get(url).json()['mediaUrl']
 
 

--- a/subs.py
+++ b/subs.py
@@ -21,7 +21,7 @@ from nrktv import session as requests
 
 
 def get_subtitles(video_id):
-    html = requests.get("http://v7.psapi.nrk.no/programs/%s/subtitles/tt" % video_id).text
+    html = requests.get("http://v8.psapi.nrk.no/programs/%s/subtitles/tt" % video_id).text
     if not html:
         return None
 


### PR DESCRIPTION
Looks compatible, doesn't seem to break anything. Fixes a issue with v7 subtitle api only returning metadata, not actual subtitles.