### PR TITLE
Split search results on div inside li

### DIFF
--- a/nrktv.py
+++ b/nrktv.py
@@ -118,14 +118,14 @@ def get_search_results(query, page=0):
     html = session.get(url).text
     lis = parseDOM(html, 'div', attrs= {'class': 'air'})
 
-    titles = [parseDOM(li, 'img', ret='alt')[0] for li in lis]
-    titles = map(html_decode, titles)
+    titles = [parseDOM(li, 'h3')[0] for li in lis]
+    titles = [html_decode(common.stripTags(_).replace('\n', ' ')) for _ in titles]
 
     urls = [parseDOM(li, 'a', ret='href')[0] for li in lis]
     urls = [url.replace('http://tv.nrk.no', '') for url in urls]
 
-    descr = [parseDOM(li, 'h3')[0] for li in lis]
-    descr = [html_decode(common.stripTags(_)) for _ in descr]
+    descr = [parseDOM(li, 'p')[0] for li in lis]
+    descr = [html_decode(common.stripTags(_).replace('&hellip;', '')) for _ in descr]
 
     thumbs = [parseDOM(li, 'img', ret='src')[0] for li in lis]
     fanart = [_fanart_url(url) for url in urls]

--- a/nrktv.py
+++ b/nrktv.py
@@ -116,7 +116,7 @@ def _json_list(url):
 def get_search_results(query, page=0):
     url = "http://tv.nrk.no/sokmaxresults?q=%s&page=%s" % (query, page)
     html = session.get(url).text
-    lis = parseDOM(html, 'li')
+    lis = parseDOM(html, 'div', attrs= {'class': 'air'})
 
     titles = [parseDOM(li, 'img', ret='alt')[0] for li in lis]
     titles = map(html_decode, titles)


### PR DESCRIPTION
To avoid finding other li's (e.g. program hosts) inside the search result we split on the div[class=air] which is
the first child element of the search-hit li instead.


In theory something like the following should work as well;

```python
lis = parseDOM(html, 'li', attrs= {'class': '.*search-hit.*'})
```

But for what ever reason, that seems to find only 1 element and that element is _everything_. Which is why I ended up with the div[class=air] instead.

The reason for this pull request is the following script error in Kodi 14 causing the search to fail. The 'li' search end up finding inner 'li' elements describing the program hosts which does not contain a image tag with a alt attribute as assumed should be in a li later in the script.

```python
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
     - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <type 'exceptions.IndexError'>
    Error Contents: list index out of range
    Traceback (most recent call last):
      File "/storage/.kodi/addons/plugin.video.nrk/default.py", line 270, in <module>
        plugin.run()
      File "/storage/.kodi/addons/plugin.video.nrk/routing.py", line 75, in run
        self._dispatch(path)
      File "/storage/.kodi/addons/plugin.video.nrk/routing.py", line 85, in _dispatch
        view_func(**kwargs)
      File "/storage/.kodi/addons/plugin.video.nrk/default.py", line 211, in search
        plugin.redirect('/search/%s/0' % quote(query))
      File "/storage/.kodi/addons/plugin.video.nrk/routing.py", line 78, in redirect
        self._dispatch(path)
      File "/storage/.kodi/addons/plugin.video.nrk/routing.py", line 85, in _dispatch
        view_func(**kwargs)
      File "/storage/.kodi/addons/plugin.video.nrk/default.py", line 217, in search_results
        results = nrktv.get_search_results(query, page)
      File "/storage/.kodi/addons/plugin.video.nrk/nrktv.py", line 121, in get_search_results
        titles = [parseDOM(li, 'img', ret='alt')[0] for li in lis]
    IndexError: list index out of range
    -->End of Python script error report<--
```