### PR TITLE
Fixes the HTTP precondition error by increasing the android-version-number

### DIFF
--- a/nrktv.py
+++ b/nrktv.py
@@ -22,7 +22,7 @@ from requests import Session
 
 session = Session()
 session.headers['User-Agent'] = 'kodi.tv'
-session.headers['app-version-android'] = '999'
+session.headers['app-version-android'] = '2500'
 
 
 class ImageMixin(object):


### PR DESCRIPTION
Makes the plugin work again.
I just found out that the API is going to be deprecated, but I don't want to take the sorrows before they happen. We'll figure something out. :)