### PR TITLE
fetch correct set of categories

### DIFF
--- a/nrktv.py
+++ b/nrktv.py
@@ -261,7 +261,7 @@ def radios():
 
 
 def categories():
-    return [Category.from_response(item) for item in _get('/medium/tv/categories')]
+    return [Category.from_response(item) for item in _get('/medium/tv/categories/')]
 
 
 def _to_series_or_program(item):


### PR DESCRIPTION
This PR fetches the categories from a different URL. All categories can be successfully opened.

fixes #63