### PR TITLE
Convert to Kodi 19 Matrix

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -126,7 +126,7 @@ def show_season_list(series_id, seasons):
     endOfDirectory(plugin.handle)
 
 def show_episode_list(episodes):
-    episodes = filter(lambda ep: getattr(ep, 'available', True), episodes)
+    episodes = [ep for ep in episodes if getattr(ep, 'available', True)]
     for i, item in enumerate(episodes):
         li = ListItem("%s - %s" % (item.episode, item.title))
         set_common_properties(item, li)
@@ -143,7 +143,7 @@ def show_episode_list(episodes):
 
 
 def show_plug_list(items):
-    items = filter(lambda ep: getattr(ep, 'available', True), items)
+    items = [ep for ep in items if getattr(ep, 'available', True)]
     for i, item in enumerate(items):
         title = item.title
         if item.episode:
@@ -201,7 +201,7 @@ def category(category_id):
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_PLAYLIST_ORDER)
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_FOLDERS)
     items = nrktv.programs(category_id)
-    view(items, urls=map(_to_series_or_program_url, items))
+    view(items, urls=list(map(_to_series_or_program_url, items)))
 
 
 @plugin.route('/browse')
@@ -219,8 +219,8 @@ def search():
     keyboard.doModal()
     query = keyboard.getText()
     if query:
-        items = nrktv.search(query.decode('utf-8'))
-        view(items, urls=map(_to_series_or_program_url, items))
+        items = nrktv.search(query)
+        view(items, urls=list(map(_to_series_or_program_url, items)))
 
 
 @plugin.route('/series/<series_id>')

--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
        version="4.7.0"
        provider-name="takoi">
   <requires>
-    <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.requests" version="1.0.4"/>
     <import addon="script.module.routing" version="0.1.0"/>
   </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -19,7 +19,11 @@
     <description lang="en">NRK Web TV gives you the opportunity to watch live TV as well as recordings of many shows.</description>
     <description lang="no">NRK Nett-TV gir deg muligheten til å se mange av NRKs programmer både direkte og i opptak.</description>
     <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
-    <forum>http://forum.xbmc.org/showthread.php?tid=52824</forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=52824</forum>
     <source>https://github.com/tamland/xbmc-addon-nrk</source>
+    <assets>
+      <icon>icon.png</icon>
+      <fanart>fanart.jpg</fanart>
+    </assets>
   </extension>
 </addon>

--- a/nrktv.py
+++ b/nrktv.py
@@ -261,7 +261,7 @@ def radios():
 
 
 def categories():
-    return [Category.from_response(item) for item in _get('/medium/tv/categories')]
+    return [Category.from_response(item) for item in _get('/medium/tv/categories/')]
 
 
 def _to_series_or_program(item):

--- a/nrktv.py
+++ b/nrktv.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
+
 
 import datetime
 import re
@@ -274,7 +274,7 @@ def programs(category_id):
     items = _get('/medium/tv/categories/%s/indexelements' % category_id)
     items = [item for item in items if item.get('title', '').strip() != ''
              and item['hasOndemandRights']]
-    return map(_to_series_or_program, items)
+    return list(map(_to_series_or_program, items))
 
 
 def _hit_to_series_or_program(item):
@@ -290,4 +290,4 @@ def search(query):
     response = _get('/search', '&q=' + query)
     if response['hits'] is None:
         return []
-    return filter(None, map(_hit_to_series_or_program, response['hits']))
+    return [_f for _f in map(_hit_to_series_or_program, response['hits']) if _f]

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<strings>
-    <string id="30002">Subtitles</string>
-    <string id="30003">Off</string>
-    <string id="30004">On</string>
-    <string id="30005">Bitrate can be selected in Settings->System-></string>
-    <string id="30006">Internet access->Internet connection bandwidth limitation</string>
-</strings>

--- a/resources/language/Norwegian/strings.xml
+++ b/resources/language/Norwegian/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<strings>
-    <string id="30002">Teksting</string>
-    <string id="30003">Av</string>
-    <string id="30004">På</string>
-    <string id="30005">Bitrate kan bli valgt i Innstillinger-></string>
-    <string id="30006">System->Internettilgang->Båndbreddebegrensning</string>
-</strings>

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,39 @@
+# Kodi Media Center language file
+# Addon Name: NRK Nett-TV
+# Addon id: plugin.video.nrk
+# Addon Provider: takoi
+msgid ""
+msgstr ""
+"Project-Id-Version: Kodi Addons\n"
+"Report-Msgid-Bugs-To: https://github.com/tamland/xbmc-addon-nrk\n"
+"POT-Creation-Date: 2021-09-04 20:20+CEST\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: tamland\n"
+"Language-Team: tamland\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30002"
+msgid "Subtitles"
+msgstr ""
+
+msgctxt "#30003"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30004"
+msgid "On"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Bitrate can be selected in Settings->System->"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Internet access->Internet connection bandwidth limitation"
+msgstr ""
+
+

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -1,0 +1,39 @@
+# Kodi Media Center language file
+# Addon Name: NRK Nett-TV
+# Addon id: plugin.video.nrk
+# Addon Provider: takoi
+msgid ""
+msgstr ""
+"Project-Id-Version: Kodi Addons\n"
+"Report-Msgid-Bugs-To: https://github.com/tamland/xbmc-addon-nrk\n"
+"POT-Creation-Date: 2021-09-04 2020+CEST\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: tamland\n"
+"Language-Team: tamland\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: nb_NO\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30002"
+msgid "Subtitles"
+msgstr "Teksting"
+
+msgctxt "#30003"
+msgid "Off"
+msgstr "Av"
+
+msgctxt "#30004"
+msgid "On"
+msgstr "På"
+
+msgctxt "#30005"
+msgid "Bitrate can be selected in Settings->System->"
+msgstr "Bitrate kan bli valgt i Innstillinger->"
+
+msgctxt "#30006"
+msgid "Internet access->Internet connection bandwidth limitation"
+msgstr "System->Internettilgang->Båndbreddebegrensning"
+
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,40 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-    <setting id="showsubtitles" type="enum" label="30002" lvalues="30003|30004" default="1"/>
-    <setting label="30005" type="lsep"/>
-    <setting label="30006" type="lsep"/>
+<settings version="1">
+  <section id="plugin.video.nrk">
+    <category id="general" label="" help="">
+      <group id="1" label="">
+        <setting id="showsubtitles" type="integer" label="30002" help="">
+          <level>0</level>
+	  <default>1</default>
+	  <constraints>
+            <options>
+              <option label="30003">0</option>
+              <option label="30004">1</option>
+            </options>
+	  </constraints>
+	  <control type="spinner" format="string"/>
+        </setting>
+        <setting id="text1" type="string" label="30005" help="">
+          <level>0</level>
+          <default/>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>30005</heading>
+          </control>
+         </setting>
+        <setting id="text2" type="string" label="30006" help="">
+          <level>0</level>
+          <default/>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>30006</heading>
+          </control>
+         </setting>
+      </group>
+    </category>
+  </section>
 </settings>


### PR DESCRIPTION
- Converts plugin to python3
- Fixes some issues found by https://github.com/xbmc/addon-check
before:
```
$ kodi-addon-checker --branch matrix xbmc-addon-nrk/
INFO: Checking add-on xbmc-addon-nrk
INFO: Created by takoi
ERROR: Addon id and folder name does not match.
INFO: Valid XML file found
WARN: http://forum.xbmc.org/showthread.php?tid=52824 redirects to https://forum.kodi.tv/showthread.php?tid=52824
INFO: Image icon exists
ERROR: Image icon should be explicitly declared in addon.xml <assets>.
INFO: icon dimensions are fine 256x256
INFO: Image fanart exists
ERROR: Image fanart should be explicitly declared in addon.xml <assets>.
INFO: fanart dimensions are fine 1280x720
INFO: fanart file size is fine 138KB
ERROR: Found ./xbmc-addon-nrk/resources/language/English/strings.xml please migrate to strings.po.
ERROR: Found ./xbmc-addon-nrk/resources/language/Norwegian/strings.xml please migrate to strings.po.
ERROR: Using the old language directory structure in /home/vagrant/xbmc-addon-nrk/resources/language/English, please move to the new one.
ERROR: Using the old language directory structure in /home/vagrant/xbmc-addon-nrk/resources/language/Norwegian, please move to the new one.
WARN: Found non whitelisted file ending in filename ./xbmc-addon-nrk/.gitattributes
WARN: Found non whitelisted file ending in filename ./xbmc-addon-nrk/.gitignore
ERROR: We found 7 problems and 3 warnings, please check the logfile.
```
after:
```
$ kodi-addon-checker --branch matrix xbmc-addon-nrk
INFO: Checking add-on xbmc-addon-nrk
INFO: Created by takoi
ERROR: Addon id and folder name does not match.
INFO: Valid XML file found
INFO: Image icon exists
INFO: icon dimensions are fine 256x256
INFO: Image fanart exists
INFO: fanart dimensions are fine 1280x720
INFO: fanart file size is fine 138KB
INFO: PO files are valid
WARN: Found non whitelisted file ending in filename ./xbmc-addon-nrk/.gitattributes
WARN: Found non whitelisted file ending in filename ./xbmc-addon-nrk/.gitignore
ERROR: We found 1 problems and 2 warnings, please check the logfile.
```
- converts the settings.xml to the new Kodi 19 Matrix format (I used https://kodi.wiki/view/Add-on_settings_conversion)
- The two last points in the settings menu look a bit weird, as I couldn't figure out how to just add text, without making the text a new setting. So you are now able to enter some text for the last two settings, which will be ignored.
- I used https://github.com/arnesongit/script.language-convert to convert the language files (I added tamland as the translator, I hope that's ok)

fixes #56 and #64 