### PR TITLE
Fix radio title

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -63,7 +63,7 @@ def live():
         li.setProperty('mimetype', "audio/mpeg")
         li.setProperty('isplayable', 'true')
         li.setArt({'thumb': rd.thumb, 'fanart': rd.fanart})
-        li.setInfo('video', {'title': ch.title})
+        li.setInfo('video', {'title': rd.title})
         li.addStreamInfo('audio', {'codec': 'aac', 'channels': 2})
         addDirectoryItem(plugin.handle,
                          plugin.url_for(live_resolve, rd.manifest.split('/')[-1]), li, False)

--- a/addon.py
+++ b/addon.py
@@ -80,7 +80,7 @@ def live_resolve(id):
     setResolvedUrl(plugin.handle, success, li)
 
 
-def set_steam_details(item, li):
+def set_stream_details(item, li):
     li.setProperty('isplayable', 'true')
     li.addStreamInfo('video', {'codec': 'h264', 'width': 1280, 'height': 720, 'duration': item.duration})
     li.addStreamInfo('audio', {'codec': 'aac', 'channels': 2})
@@ -112,7 +112,7 @@ def view(items, update_listing=False, urls=None):
         set_common_properties(item, li)
         playable = plugin.route_for(url) == play
         if playable:
-            set_steam_details(item, li)
+            set_stream_details(item, li)
         li.setInfo('video', {'count': i, 'title': item.title, 'mediatype': 'video'})
         addDirectoryItem(plugin.handle, url, li, not playable, total)
     endOfDirectory(plugin.handle, updateListing=update_listing)
@@ -130,7 +130,7 @@ def show_episode_list(episodes):
     for i, item in enumerate(episodes):
         li = ListItem("%s - %s" % (item.episode, item.title))
         set_common_properties(item, li)
-        set_steam_details(item, li)
+        set_stream_details(item, li)
         li.setInfo('video', {
             'title': item.title,
             'count': i,
@@ -150,7 +150,7 @@ def show_plug_list(items):
             title += " (%s)" % item.episode
         li = ListItem(title)
         set_common_properties(item, li)
-        set_steam_details(item, li)
+        set_stream_details(item, li)
         li.setInfo('video', {
             'title': title,
             'count': i,


### PR DESCRIPTION
Fix title for radio channels
    When listening on radio, the title was wrong, it always showed the last TV title.

This also fixes a minor typo in a function.