### PR TITLE
Update license to SPDX format in addon.xml

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -18,8 +18,8 @@
     <summary lang="no">Se NRK Nett-TV</summary>
     <description lang="en">NRK Web TV gives you the opportunity to watch live TV as well as recordings of many shows.</description>
     <description lang="no">NRK Nett-TV gir deg muligheten til å se mange av NRKs programmer både direkte og i opptak.</description>
-    <description lang="it">Questo addon per Kodi rende possibile la visione di molti programmi di NRK sia in diretta che in differita.</description>     
-    <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
+    <description lang="it">Questo addon per Kodi rende possibile la visione di molti programmi di NRK sia in diretta che in differita.</description>
+    <license>GPL-3.0-or-later</license>
     <forum>https://forum.kodi.tv/showthread.php?tid=52824</forum>
     <source>https://github.com/tamland/xbmc-addon-nrk</source>
     <assets>


### PR DESCRIPTION
The license file and the license notice in the Python files does not align
with the license mentioned in addon.xml. The XML file specifies
"GPL-3.0-only" while the license file mentions "GPL-3.0-or-later".
This updates the license identifier to SPDX format and changes it to
"GPL-3.0-or-later".

The use of SPDX format was originally requested in the latest upload to the official Kodi add-ons repository (https://github.com/xbmc/repo-plugins/pull/4290#pullrequestreview-1357825279).