### PR TITLE
feat: add on-demand radio categories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .github export-ignore
+tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# VS Code
+.vscode
+
+# Developer files
+TODO.md

--- a/addon.py
+++ b/addon.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from nrk import Base
 import time
 import xbmc
 import xbmcplugin
@@ -26,6 +27,8 @@ from xbmcplugin import setResolvedUrl
 from xbmcgui import ListItem
 import routing
 import nrktv
+import nrkradio
+import nrk
 import subs
 import inputstreamhelper
 
@@ -35,8 +38,16 @@ plugin = routing.Plugin()
 @plugin.route('/')
 def root():
     items = [
+        (plugin.url_for(tv), ListItem("TV"), True),
+        (plugin.url_for(radio), ListItem("Radio"), True),
+    ]
+    addDirectoryItems(plugin.handle, items)
+    endOfDirectory(plugin.handle)
+
+@plugin.route('/tv')
+def tv():
+    items = [
         (plugin.url_for(live_tv), ListItem("Direkte TV"), True),
-        (plugin.url_for(live_radio), ListItem("Direkte radio"), True),
         (plugin.url_for(recommended), ListItem("Anbefalt"), True),
         (plugin.url_for(popular), ListItem("Mest sett"), True),
         (plugin.url_for(mostrecent), ListItem("Sist sendt"), True),
@@ -220,6 +231,70 @@ def browse():
     items = nrktv.categories()
     urls = [plugin.url_for(category, item.id) for item in items]
     view(items, urls=urls)
+
+@plugin.route('/radio')
+def radio():
+    items = [
+        (plugin.url_for(live_radio), ListItem("Direkte radio"), True),
+        (plugin.url_for(radio_pages), ListItem("Kategorier"), True),
+    ]
+    addDirectoryItems(plugin.handle, items)
+    endOfDirectory(plugin.handle)
+
+
+@plugin.route('/radio/pages')
+def radio_pages():
+    items: list[Base] = nrkradio.PagesOverview().children
+    show_radio_list(items)
+
+@plugin.route('/radio/<string:type>/<path:url>')
+def radio_navigate_by_url(type: str, url: str) -> None:
+    item_class = nrkradio.map_type_to_class(type)
+    item: Base = item_class.from_url(url)
+    children: list[Base] = item.children
+    if children:
+        show_radio_list(children)
+    else:
+        media_url = item.media_url
+        if media_url:
+            li = ListItem(item.title, path=media_url)
+            set_common_properties(item, li)
+            playable = True
+            #if playable:
+                # set_stream_details(podcastEpisode, li)
+            li.setProperty('isplayable', 'true')
+            xbmcplugin.setResolvedUrl(plugin.handle, True, listitem=li)
+            addDirectoryItem(plugin.handle, media_url, li, not playable)
+            endOfDirectory(plugin.handle)
+
+
+def show_radio_list(items: list[nrk.Base]):
+    total: int = len(items)
+    for item in items:
+        # if not getattr(item, 'available', True):
+        #    continue
+        li = ListItem(item.title)
+        # set_common_properties(item, li) TODO: set metadata
+        playable = item.is_playable
+        if playable:
+            li.setProperty('isplayable', 'true')
+        child_type = item.type
+        manifest_url = item.manifest_url
+        url = plugin.url_for(radio_navigate_by_url, child_type, manifest_url)
+        art: dict[str, str] = {}
+        if item.fanart:
+            xbmc.log(f"setting fanart {item.title}: {item.fanart}", xbmc.LOGINFO)
+            art["fanart"] = item.fanart
+        if item.thumb:
+            art["thumb"] = item.thumb
+        if art:
+            li.setArt(art)
+        #tag = li.getMusicInfoTag()
+
+        #li.setInfo('video', {'count': i, 'title': item.title, 'mediatype': 'video'})
+        addDirectoryItem(plugin.handle, url, li, not playable, total)
+    endOfDirectory(plugin.handle)
+
 
 
 @plugin.route('/search')

--- a/nrk.py
+++ b/nrk.py
@@ -1,0 +1,139 @@
+from enum import Enum
+from typing import Any, override
+
+
+from requests.models import Response
+
+
+from requests import Session
+
+session = Session()
+session.headers["User-Agent"] = "kodi.tv"
+
+
+class Base(object):
+    def __init__(
+        self,
+        id: str | None,
+        title: str | None,
+        type: Enum,
+        is_playable: bool,
+        manifest_url: str | None,
+    ):
+        self.__id: str | None = id
+        self.__title: str | None = title
+        self.__type: Enum = type
+        self.__is_playable: bool = is_playable
+        self.__manifest_url: str | None = manifest_url  # must be an absolute path
+        self.__children: list[Base] = []
+        self.__media_url: str | None = None
+        self.thumb: str | None = None
+        self.fanart: str | None = None
+
+    def __str__(self):
+        return f"{self.__class__.__name__}: { {str(self.__id)}, {str(self.__title)} }"
+
+    @property
+    def id(self) -> str | None:
+        return self.__id
+
+    @property
+    def title(self) -> str:
+        return self.__title or "Ingen tittel"
+
+    @property
+    def manifest_url(self) -> str | None:
+        return self.__manifest_url
+
+    def append_child(self, child: "Base") -> None:
+        self.__children.append(child)
+
+    @property
+    def children(self) -> list["Base"]:
+        return self.__children
+
+    @property
+    def is_playable(self) -> bool:
+        return self.__is_playable
+
+    @property
+    def type(self) -> str:
+        return self.__type.value
+
+    @property
+    def media_url(self) -> str | None:
+        if self.__is_playable:
+            return self.__media_url
+        return None
+
+    @media_url.setter
+    def media_url(self, value: str | None) -> None:
+        self.__media_url = value
+
+    def add_images(self, images) -> None:
+        self.thumb = deep_get_str(images, 0, "url")
+        self.fanart = deep_get_str(images, -1, "url")
+
+
+class BasePage(Base):
+    @override
+    def add_images(self, images) -> None:
+        self.thumb = deep_get_str(images, 0, "uri")
+        self.fanart = deep_get_str(images, -1, "uri")
+
+
+def get(path: str, params: str = "") -> Any:
+    api_key = "d1381d92278a47c09066460f2522a67d"
+    if len(params) > 0 and params[0] != "&":
+        raise ValueError("params must start with &")
+    r: Response = session.get(
+        "https://psapi.nrk.no{}?apiKey={}{}".format(path, api_key, params)
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def deep_get(obj: Any, *keys: int | str) -> Any | None:
+    if len(keys) == 0:
+        return None
+
+    key: int | str = keys[0]
+
+    if isinstance(key, str) and isinstance(obj, dict):
+        value: Any | None = obj.get(key)
+
+    elif isinstance(key, int) and isinstance(obj, list):
+        if len(obj) <= key or key < -len(obj):
+            return None
+        value: Any | None = obj[key]
+    else:
+        return None
+
+    if len(keys) >= 2:
+        return deep_get(value, *keys[1:])
+    else:
+        return value
+
+
+def deep_get_str(obj: Any, *keys: int | str) -> str | None:
+    value: Any | None = deep_get(obj, *keys)
+    if isinstance(value, str):
+        return value
+    else:
+        return None
+
+
+def deep_get_dict(obj: Any, *keys: int | str) -> dict[Any, Any]:
+    value: Any | None = deep_get(obj, *keys)
+    if isinstance(value, dict):
+        return value
+    else:
+        return {}
+
+
+def deep_get_list(obj: Any, *keys: int | str) -> list[Any]:
+    value: Any | None = deep_get(obj, *keys)
+    if isinstance(value, list):
+        return value
+    else:
+        return []

--- a/nrkradio.py
+++ b/nrkradio.py
@@ -1,0 +1,607 @@
+from enum import Enum
+from typing import Any, Self, override
+import nrk
+from nrk import deep_get_str, deep_get_dict, deep_get_list
+
+
+class Type(Enum):
+    CHANNEL = "channel"
+    PAGE = "page"
+    PAGESOVERVIEW = "pagesoverview"
+    PODCAST = "podcast"
+    PODCASTEPISODE = "podcastepisode"
+    SEASON = "season"
+    SECTION = "section"
+    SERIES = "series"
+    STANDALONEPROGRAM = "standaloneprogram"
+
+
+class PagesOverview(nrk.BasePage):
+    def __init__(self):
+        response = nrk.get("/radio/pages")
+        title: str | None = deep_get_str(response, "title")
+        id: str | None = deep_get_str(response, "id")
+        super().__init__(id, title, Type.PAGESOVERVIEW, False, "/radio/pages")
+        for page in deep_get_list(response, "pages"):
+            page_id: str | None = deep_get_str(page, "id")
+            self.append_child(Page(page_id, page))
+
+
+class Page(nrk.BasePage):
+
+    def __init__(self, page_id: str | None, response: Any):
+        title: str | None = deep_get_str(response, "title")
+        super().__init__(page_id, title, Type.PAGE, False, f"/radio/pages/{page_id}")
+        super().add_images(deep_get_list(response, "image", "webImages"))
+        for index, item in enumerate(deep_get_list(response, "sections")):
+            self.append_child(Section(page_id, str(index), item))
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if len(dirs) != 4 or dirs[1] != "radio" or dirs[2] != "pages":
+            raise ValueError("Wrong format of url")
+        page_id: str = dirs[3]
+        # https://psapi.nrk.no/documentation/redoc/pages-radio/v3.6/#tag/Pages/operation/GetGivenNRKRadioPage
+        return cls(page_id, nrk.get(f"/radio/pages/{page_id}"))
+
+
+class PlugInfo:
+    def __init__(
+        self,
+        id: str | None,
+        title: str | None,
+        type: Enum,
+        is_playable: bool,
+        manifest_url: str | None,
+        images: list[dict[str, str | int]] | str | None,
+    ) -> None:
+        self.id: str | None = id
+        self.title: str | None = title
+        self.type: Enum = type
+        self.is_playable: bool = is_playable
+        self.manifestUrl: str | None = manifest_url
+        self.images: list[dict[str, str | int]] | str | None = images
+
+
+class BasePlug(nrk.BasePage):
+
+    def __init__(self, response: dict[Any, Any]):
+        self.response: dict[Any, Any] = response
+        pluginfo: PlugInfo = self._extract()
+        super().__init__(
+            id=pluginfo.id,
+            title=pluginfo.title,
+            type=pluginfo.type,
+            is_playable=pluginfo.is_playable,
+            manifest_url=pluginfo.manifestUrl,
+        )
+        if pluginfo.images:
+            self.add_images(pluginfo.images)
+
+    def _extract(self) -> PlugInfo:
+        """Sub-classes override this method to extract the fields they need."""
+        raise NotImplementedError
+
+
+class Section(nrk.Base):
+
+    def __init__(self, page_id, section_id: str, response):
+
+        # response can be full response or just the respective section of the response
+        if response.get("sections", None):
+            response = deep_get_dict(response, "sections", int(section_id))
+
+        plugs_response = []
+        if response.get("included", None):
+            title = deep_get_str(response, "included", "title")
+            plugs_response = deep_get_list(response, "included", "plugs")
+        elif response.get("placeholder", None):
+            title = deep_get_str(response, "placeholder", "title")
+            plugs_response = deep_get_list(response, "placeholder", "plugs")
+        else:
+            title: str | None = None
+            plugs_response: list[Any] = []
+        super().__init__(
+            str(section_id),
+            title,
+            Type.SECTION,
+            False,
+            f"/pages/{page_id}/{section_id}",
+        )
+        for item in plugs_response:
+            plug: BasePlug = plug_factory(item)
+            super().append_child(plug)
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if len(dirs) != 4:
+            raise ValueError("Wrong format of url")
+        page_id: str = dirs[2]
+        section_id: str = dirs[3]
+        # Same request as for radio_page() as the request for a section does not work
+        # https://psapi.nrk.no/documentation/redoc/pages-radio/v3.6/#tag/Pages/operation/GetGivenNRKRadioPage
+        return cls(page_id, section_id, nrk.get("/radio/pages/" + page_id))
+
+
+class ChannelPlug(BasePlug):
+    def _extract(self) -> PlugInfo:
+        channel: dict[Any, Any] = deep_get_dict(self.response, "channel")
+        channel_title: str | None = deep_get_str(channel, "titles", "title")
+        manifest_url = deep_get_str(self.response, "_links", "channel")
+        images: list[dict[str, str | int]] = deep_get_list(
+            channel, "image", "webImages"
+        )
+        return PlugInfo(
+            None,
+            channel_title,
+            Type.CHANNEL,
+            is_playable=True,
+            manifest_url=manifest_url,
+            images=images,
+        )
+
+
+class PodcastEpisodePlug(BasePlug):
+    @override
+    def _extract(self) -> PlugInfo:
+        podcastEpisode: dict[Any, Any] = deep_get_dict(self.response, "podcastEpisode")
+        podcast_title: str | None = deep_get_str(
+            podcastEpisode, "podcast", "titles", "title"
+        )
+        episode_title: str | None = deep_get_str(podcastEpisode, "titles", "title")
+        if episode_title:
+            title: str = f"{podcast_title}: {episode_title}"
+        else:
+            episode_subtitle: str | None = deep_get_str(
+                podcastEpisode, "titles", "subtitle"
+            )
+            title = f"{podcast_title}: {episode_subtitle}"
+        manifest_url: str | None = deep_get_str(
+            self.response, "_links", "podcastEpisode"
+        )
+        images: str | None = deep_get_str(podcastEpisode, "imageUrl")
+        return PlugInfo(
+            None,
+            title,
+            Type.PODCASTEPISODE,
+            is_playable=True,
+            manifest_url=manifest_url,
+            images=images,
+        )
+
+    @override
+    def add_images(self, images: str) -> None:
+        self.thumb = images
+        self.fanart = images
+
+
+class StandaloneProgramPlug(BasePlug):
+    @override
+    def _extract(self) -> PlugInfo:
+        standaloneProgram: dict[Any, Any] = deep_get_dict(self.response, "program")
+        program_title: str | None = deep_get_str(standaloneProgram, "titles", "title")
+        program_subtitle: str | None = deep_get_str(
+            standaloneProgram, "titles", "subtitle"
+        )
+        if program_title:
+            title: str = f"{program_title}: {program_subtitle}"
+        else:
+            title = f"{program_subtitle}"
+        manifest_url: str | None = deep_get_str(self.response, "_links", "program")
+        images: list[dict[str, str | int]] = deep_get_list(
+            standaloneProgram, "image", "webImages"
+        )
+        return PlugInfo(
+            None,
+            title,
+            Type.STANDALONEPROGRAM,
+            is_playable=True,
+            manifest_url=manifest_url,
+            images=images,
+        )
+
+
+class PodcastPlug(BasePlug):
+    @override
+    def _extract(self) -> PlugInfo:
+        podcast: dict[Any, Any] = deep_get_dict(self.response, "podcast")
+        podcast_title: str | None = deep_get_str(podcast, "titles", "title")
+        podcast_subtitle: str | None = deep_get_str(podcast, "titles", "subtitle")
+        if podcast_title:
+            title: str = f"{podcast_title}: {podcast_subtitle}"
+        else:
+            title = f"{podcast_subtitle}"
+        manifest_url: str | None = deep_get_str(self.response, "_links", "podcast")
+        images: str | None = deep_get_str(podcast, "imageUrl")
+        return PlugInfo(
+            None,
+            title,
+            Type.PODCAST,
+            is_playable=False,
+            manifest_url=manifest_url,
+            images=images,
+        )
+
+    @override
+    def add_images(self, images: str) -> None:
+        self.thumb = images
+        self.fanart = images
+
+
+class EpisodePlug(BasePlug):
+    @override
+    def _extract(self) -> PlugInfo:
+        episode: dict[Any, Any] = deep_get_dict(self.response, "episode")
+        series_title: str | None = deep_get_str(episode, "series", "titles", "title")
+        episode_title: str | None = deep_get_str(episode, "titles", "title")
+        episode_subtitle: str | None = deep_get_str(episode, "titles", "subtitle")
+        title: str = f"{series_title}: {episode_title}: {episode_subtitle}"
+        manifest_url: str | None = deep_get_str(self.response, "_links", "episode")
+        images: list[dict[str, str | int]] = deep_get_list(
+            episode, "image", "webImages"
+        )
+        return PlugInfo(
+            None,
+            title,
+            Type.PODCASTEPISODE,
+            is_playable=True,
+            manifest_url=manifest_url,
+            images=images,
+        )
+
+
+class SeriesPlug(BasePlug):
+    def _extract(self):
+        series: dict[Any, Any] = deep_get_dict(self.response, "series")
+        series_title: str | None = deep_get_str(series, "titles", "title")
+        series_subtitle: str | None = deep_get_str(series, "titles", "subtitle")
+        if series_title:
+            title: str = f"{series_title}: {series_subtitle}"
+        else:
+            title = f"{series_subtitle}"
+        manifest_url: str | None = deep_get_str(self.response, "_links", "series")
+        images: list[dict[str, str | int]] = deep_get_list(series, "image", "webImages")
+        return PlugInfo(
+            None,
+            title,
+            Type.SERIES,
+            is_playable=False,
+            manifest_url=manifest_url,
+            images=images,
+        )
+
+
+def plug_factory(response: dict[str, Any]) -> BasePlug:
+    """Return an appropriate Plug instance based on response['type']."""
+    type_map: dict[
+        str,
+        type[ChannelPlug]
+        | type[PodcastEpisodePlug]
+        | type[StandaloneProgramPlug]
+        | type[PodcastPlug]
+        | type[EpisodePlug]
+        | type[SeriesPlug],
+    ] = {
+        "channel": ChannelPlug,
+        "podcastEpisode": PodcastEpisodePlug,
+        "standaloneProgram": StandaloneProgramPlug,
+        "podcast": PodcastPlug,
+        "episode": EpisodePlug,
+        "series": SeriesPlug,
+    }
+    plug_type = deep_get_str(response, "type")
+    if not plug_type:
+        raise ValueError("No type found in plug")
+    plug_class: (
+        type[ChannelPlug]
+        | type[PodcastEpisodePlug]
+        | type[StandaloneProgramPlug]
+        | type[PodcastPlug]
+        | type[EpisodePlug]
+        | type[SeriesPlug]
+        | None
+    ) = type_map.get(plug_type)
+    if not plug_class:
+        raise ValueError(f"Unsupported plug type: {plug_type}")
+
+    return plug_class(response)
+
+
+class PodcastEpisode(nrk.Base):
+
+    def __init__(
+        self,
+        title: str | None,
+        podcast_series_id: str | None,
+        podcast_episode_id: str | None,
+        images: list[dict[str, str | int]],
+    ):
+
+        super().__init__(
+            podcast_episode_id,
+            title,
+            Type.PODCASTEPISODE,
+            True,
+            f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}",
+        )
+        self.add_images(images)
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if (
+            len(dirs) == 6
+            and dirs[1] == "playback"
+            and dirs[2] == "manifest"
+            and dirs[3] == "podcast"
+        ):
+            # manifest url from a season
+            podcast_series_id: str = dirs[4]
+            podcast_episode_id: str = dirs[5]
+        elif len(dirs) == 5 and dirs[1] == "podcasts" and dirs[3] == "episodes":
+            # url from an PodcastEpisodePlug, the path is actually not valid
+            # but we can still use it to extract the relevant IDs
+            podcast_series_id: str = dirs[2]
+            podcast_episode_id: str = dirs[4]
+        else:
+            raise ValueError("Wrong format of url")
+        response = nrk.get(
+            f"/playback/metadata/podcast/{podcast_series_id}/{podcast_episode_id}"
+        )
+        podcastepisode_title: str | None = deep_get_str(
+            response, "preplay", "titles", "title"
+        )
+        podcastepisode_subtitle: str | None = deep_get_str(
+            response, "preplay", "titles", "subtitle"
+        )
+        images: list[dict[str, str | int]] = deep_get_list(
+            response, "preplay", "poster", "images"
+        )
+        return cls(
+            f"{podcastepisode_title}: {podcastepisode_subtitle}",
+            podcast_series_id,
+            podcast_episode_id,
+            images,
+        )
+
+    @nrk.Base.media_url.getter
+    def media_url(self) -> str | None:
+        manifest_url: str | None = self.manifest_url
+        if not super().media_url and manifest_url:
+            response = nrk.get(manifest_url)
+            self.media_url = deep_get_str(response, "playable", "assets", 0, "url")
+        return super().media_url
+
+
+class StandaloneProgram(nrk.Base):
+
+    def __init__(self, title: str | None, program_id: str | None, images):
+
+        super().__init__(
+            program_id,
+            title,
+            Type.STANDALONEPROGRAM,
+            True,
+            f"/playback/manifest/program/{program_id}",
+        )
+        self.add_images(images)
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if (
+            len(dirs) == 5
+            and dirs[1] == "playback"
+            and dirs[2] == "manifest"
+            and dirs[3] == "program"
+        ):
+            # manifest url from a season
+            program_id: str = dirs[4]
+        elif len(dirs) == 3 and dirs[1] == "programs":
+            # manifest url from a plug
+            program_id: str = dirs[2]
+        else:
+            raise ValueError("Wrong format of url")
+        return cls(None, program_id, [])
+
+    @nrk.Base.media_url.getter
+    def media_url(self) -> str | None:
+        manifest_url: str | None = self.manifest_url
+        if not super().media_url and manifest_url:
+            response = nrk.get(manifest_url)
+            self.media_url = deep_get_str(response, "playable", "assets", 0, "url")
+        return super().media_url
+
+
+class Season(nrk.Base):  # can be podcast or series season
+
+    def __init__(self, title: str | None, url: str | None, images: list[dict[str, str | int]]):
+        super().__init__(
+            None, title, is_playable=False, type=Type.SEASON, manifest_url=url
+        )
+        self.add_images(images)
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if (
+            len(dirs) != 7
+            or dirs[1] != "radio"
+            or dirs[2] != "catalog"
+            or (dirs[3] != "podcast" and dirs[3] != "series")
+            or dirs[5] != "seasons"
+        ):
+            raise ValueError("Wrong format of url")
+        podcast_series_id: str = dirs[4]
+        podcast_season_id: str = dirs[6]
+        response = nrk.get(url)
+        title: str | None = deep_get_str(response, "titles", "title")
+        images: list[dict[str,str|int]] = deep_get_list(response, "image")
+        return cls(title, url, images)
+
+    @property
+    @override
+    def children(self) -> list[nrk.Base]:
+        if self.manifest_url and not super().children:
+            response: dict[str, Any] = nrk.get(path=f"{self.manifest_url}")
+            series_type: str | None = deep_get_str(response, "type")
+            page = 1
+            pageSize = 50
+            while True:
+                response: dict[str, Any] = nrk.get(
+                    path=f"{self.manifest_url}/episodes",
+                    params=f"&page={page}&pageSize={pageSize}&sort=desc",
+                )
+                episodes: list[dict[str, Any]] = deep_get_list(
+                    response, "_embedded", "episodes"
+                )
+                for episode in episodes:
+                    title: str | None = deep_get_str(episode, "titles", "title")
+                    series_id: str | None = deep_get_str(
+                        episode, "_links", "series", "name"
+                    )
+                    episode_id: str | None = deep_get_str(episode, "episodeId")
+                    images: list[dict[str, str | int]] = deep_get_list(episode, "image")
+
+                    if series_type == "podcast":
+                        self.append_child(PodcastEpisode(title, series_id, episode_id, images))
+                    elif series_type == "series":
+                        self.append_child(StandaloneProgram(title, episode_id, images))
+                    else:
+                        raise ValueError("Invalid series type detected")
+                if len(episodes) < pageSize:
+                    break
+                page += 1
+        return super().children
+
+
+class Podcast(nrk.Base):
+
+    def __init__(self, podcast_series_id: str, response):
+        seasons: list[dict[str, str]] = deep_get_list(response, "_links", "seasons")
+        title: str | None = deep_get_str(response, "series", "titles", "title")
+        super().__init__(
+            podcast_series_id,
+            title,
+            Type.PODCAST,
+            False,
+            f"/radio/catalog/podcast/{podcast_series_id}",
+        )
+        super().add_images(deep_get_list(response, "series", "image"))
+        for season in seasons:
+            season_title: str | None = deep_get_str(season, "title")
+            season_url: str | None = deep_get_str(season, "href")
+            super().append_child(Season(season_title, season_url, []))
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if len(dirs) != 3 or dirs[1] != "podcasts":
+            raise ValueError("Wrong format of url")
+        podcast_series_id: str = dirs[2]
+        return cls(
+            podcast_series_id, nrk.get(f"/radio/catalog/podcast/{podcast_series_id}")
+        )
+
+
+class Channel(nrk.Base):
+
+    def __init__(self, channel_id):
+        super().__init__(
+            channel_id,
+            None,
+            Type.CHANNEL,
+            True,
+            f"/playback/manifest/channel/{channel_id}",
+        )
+        if self.manifest_url:
+            response = nrk.get(self.manifest_url)
+            self.media_url = deep_get_str(response, "playable", "assets", 0, "url")
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if len(dirs) != 3 or dirs[1] != "mediaelement":
+            raise ValueError("Wrong format of url")
+        channel_id: str = dirs[2]
+        return cls(channel_id)
+
+
+class Series(nrk.Base):
+
+    def __init__(self, series_id: str, response):
+        seasons: list[dict[str, str]] = deep_get_list(response, "_links", "seasons")
+        title: str | None = deep_get_str(response, "series", "titles", "title")
+
+        super().__init__(
+            series_id, title, Type.SERIES, False, f"/radio/catalog/series/{series_id}"
+        )
+        for season in seasons:
+            season_title: str | None = deep_get_str(season, "title")
+            season_url: str | None = deep_get_str(season, "href")
+            super().append_child(Season(season_title, season_url, []))
+
+    @classmethod
+    def from_url(cls, url: str) -> Self:
+        dirs: list[str] = url.split("/")
+        if len(dirs) != 3 or dirs[1] != "series":
+            raise ValueError("Wrong format of url")
+        series_id: str = dirs[2]
+        return cls(series_id, nrk.get(f"/radio/catalog/series/{series_id}"))
+
+
+def map_type_to_class(
+    type_string: str,
+) -> (
+    type[Channel]
+    | type[Page]
+    | type[Podcast]
+    | type[PodcastEpisode]
+    | type[Season]
+    | type[Section]
+    | type[Series]
+    | type[StandaloneProgram]
+):
+    type_map: dict[
+        Type,
+        type[Channel]
+        | type[Page]
+        | type[Podcast]
+        | type[PodcastEpisode]
+        | type[Season]
+        | type[Section]
+        | type[Series]
+        | type[StandaloneProgram],
+    ] = {
+        Type.CHANNEL: Channel,
+        Type.PAGE: Page,
+        Type.PODCAST: Podcast,
+        Type.PODCASTEPISODE: PodcastEpisode,
+        Type.SEASON: Season,
+        Type.SECTION: Section,
+        Type.SERIES: Series,
+        Type.STANDALONEPROGRAM: StandaloneProgram,
+    }
+    try:
+        item_type = Type(type_string)
+    except ValueError:
+        raise ValueError(f"No type found for: {type_string}")
+
+    item_class: (
+        type[Channel]
+        | type[Page]
+        | type[Podcast]
+        | type[PodcastEpisode]
+        | type[Season]
+        | type[Section]
+        | type[Series]
+        | type[StandaloneProgram]
+        | None
+    ) = type_map.get(item_type)
+
+    if not item_class:
+        raise ValueError(f"No class found for: {type_string}")
+
+    return item_class

--- a/tests/test_baseplug.py
+++ b/tests/test_baseplug.py
@@ -1,0 +1,8 @@
+import pytest
+
+from nrkradio import BasePlug
+
+def test_init():
+
+    with pytest.raises(NotImplementedError):
+        _ = BasePlug({})

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,0 +1,148 @@
+import pytest
+from unittest import mock
+from nrkradio import Channel
+
+
+@pytest.fixture
+def channel_manifest():
+    return {
+        "_links": {
+            "self": {"href": "/playback/manifest/channel/channel-123"},
+            "metadata": {
+                "href": "/playback/metadata/channel/channel-123",
+                "name": "metadata",
+            },
+        },
+        "id": "channel-123",
+        "playability": "playable",
+        "streamingMode": "live",
+        "availability": {
+            "information": "",
+            "isGeoBlocked": False,
+            "onDemand": None,
+            "live": {
+                "type": "channel",
+                "isOngoing": True,
+                "transmissionInterval": None,
+            },
+            "externalEmbeddingAllowed": True,
+        },
+        "statistics": {
+            "scores": {
+                "springStreamSite": "nrkradio",
+                "springStreamStream": "programspiller/live/nrk_channel-123",
+                "springStreamContentType": "other/generic_hls",
+                "springStreamProgramId": "",
+                "springStreamDuration": None,
+            },
+            "ga": {
+                "dimension1": "",
+                "dimension2": "channel-123",
+                "dimension3": "",
+                "dimension4": "",
+                "dimension5": "",
+                "dimension10": "live:channel-123",
+                "dimension21": "",
+                "dimension22": "",
+                "dimension23": "",
+                "dimension25": "audio",
+                "dimension26": "live",
+                "dimension29": "other/generic_hls",
+                "dimension36": "other-generichls|notapplicable|sliding|live|world|akamai-cdn|europeaneconomicarea|notapplicable|none|stereo|notapplicable|sd",
+            },
+            "conviva": None,
+            "luna": {
+                "config": {"beacon": "https://example.com/akamai-beacon.xml"},
+                "data": {
+                    "title": "",
+                    "device": "",
+                    "playerId": "",
+                    "deliveryType": "",
+                    "playerInfo": "",
+                    "cdnName": "Akamai-Cdn",
+                },
+            },
+            "qualityOfExperience": {
+                "mediaId": "channel-123",
+                "channelId": "channel-123",
+                "title": "Channel 123",
+                "clientName": "other-generichls",
+                "cdnName": "akamai-cdn",
+                "npawCdnName": "AKAMAI",
+                "streamingFormat": "hlsv3",
+                "segmentLength": "notapplicable",
+                "assetType": "live",
+                "correlationId": "019c497a-3b48-7af0-90e6-6cd4b2653c0a",
+                "live": True,
+                "npawCustomDimensions": {
+                    "1": "other-generichls",
+                    "2": "019c497a-3b48-7af0-90e6-6cd4b2653c0a",
+                },
+            },
+            "snowplow": {"source": "prf"},
+            "kantar": {
+                "trackingType": "live",
+                "site": "nrkradio",
+                "contentType": "other/generic_hls",
+                "stream": "programspiller/live/nrk_channel-123",
+                "duration": 0,
+                "contentId": "channel-123",
+            },
+        },
+        "playable": {
+            "endSequenceStartTime": None,
+            "duration": None,
+            "assets": [
+                {
+                    "url": "https://example.com/channel-123/muxed.m3u8?adap=audio&aco=aac",
+                    "format": "HLS",
+                    "mimeType": "application/vnd.apple.mpegurl",
+                    "encrypted": False,
+                    "encryptionScheme": "none",
+                }
+            ],
+            "liveBuffer": {
+                "bufferStartTime": None,
+                "bufferDuration": "PT3H",
+                "bufferType": "sliding",
+            },
+            "subtitles": [],
+            "thumbnails": [],
+        },
+        "nonPlayable": None,
+        "displayAspectRatio": None,
+        "sourceMedium": "audio",
+    }
+
+
+def test_init(channel_manifest):
+    channel_id = "channel-123"
+    manifest_url = f"/playback/manifest/channel/{channel_id}"
+
+    with mock.patch("nrk.get", return_value=channel_manifest) as mocked_get:
+        channel = Channel(channel_id)
+
+        mocked_get.assert_called_once_with(manifest_url)
+
+        assert channel.id == channel_id
+        assert channel.manifest_url == manifest_url
+        assert channel.media_url == "https://example.com/channel-123/muxed.m3u8?adap=audio&aco=aac"
+        assert channel.thumb == None
+        assert channel.fanart == None
+
+def test_from_url_success(channel_manifest):
+    channel_id = "channel-123"
+    manifest_url = f"/playback/manifest/channel/{channel_id}"
+
+    with mock.patch("nrk.get", return_value=channel_manifest) as mocked_get:
+        channel = Channel.from_url(f"/mediaelement/{channel_id}")
+
+        mocked_get.assert_called_once_with(manifest_url)
+
+        assert channel.id == channel_id
+        assert channel.manifest_url == manifest_url
+        assert channel.media_url == "https://example.com/channel-123/muxed.m3u8?adap=audio&aco=aac"
+
+def test_from_url_wrong_format():
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        _ = Channel.from_url("/radio/medialement/channel-123")

--- a/tests/test_channelplug.py
+++ b/tests/test_channelplug.py
@@ -1,0 +1,60 @@
+import pytest
+
+from nrkradio import ChannelPlug
+
+
+@pytest.fixture
+def channel_plug_response():
+    return {
+        "type": "channel",
+        "_links": {"channel": "/mediaelement/channelname"},
+        "channel": {
+            "titles": {"title": "Channel title"},
+            "image": {
+                "id": "019c39da-d036-70f5-9c30-9c7179f233ff",
+                "webImages": [
+                    {
+                        "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff7H9WHy0d_QEvZ41HevX4tQ",
+                        "width": 300,
+                    },
+                    {
+                        "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffnptQAWmTl0QvZ41HevX4tQ",
+                        "width": 600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffNE58lEqQAswvZ41HevX4tQ",
+                        "width": 960,
+                    },
+                    {
+                        "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffktYCmVGM_QUvZ41HevX4tQ",
+                        "width": 1280,
+                    },
+                    {
+                        "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffBdvbxUqgPHYvZ41HevX4tQ",
+                        "width": 1600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff1ean57gyYhQvZ41HevX4tQ",
+                        "width": 1920,
+                    },
+                ],
+            },
+        },
+    }
+
+
+def test_init(channel_plug_response):
+
+    channel_plug = ChannelPlug(channel_plug_response)
+
+    assert channel_plug.id == None
+    assert channel_plug.title == "Channel title"
+    assert channel_plug.manifest_url == "/mediaelement/channelname"
+    assert (
+        channel_plug.thumb
+        == "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff7H9WHy0d_QEvZ41HevX4tQ"
+    )
+    assert (
+        channel_plug.fanart
+        == "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff1ean57gyYhQvZ41HevX4tQ"
+    )

--- a/tests/test_deep_get.py
+++ b/tests/test_deep_get.py
@@ -1,0 +1,79 @@
+import pytest
+from nrk import deep_get, deep_get_str, deep_get_list, deep_get_dict
+
+
+@pytest.fixture(scope="module")
+def nested_dict():
+    """A moderately deep dictionary used by many tests."""
+    return {
+        "a": {
+            "b": {
+                "c": {"d": "A"},
+                "x": 42,
+            },
+            "y": "leaf",
+        },
+        "b": [[{"e": "f", "g": [10, 11, 12]}], [[20, 30, 40]]],
+    }
+
+
+@pytest.mark.parametrize(
+    "keys,expected",
+    [
+        (("a", "b", "c", "d"), "A"),
+        (("a", "b", "c"), {"d": "A"}),
+        (("a", "y"), "leaf"),
+        (("a", "b", "x"), 42),
+        (("b", 0, 0, "e"), "f"),
+        (("b", 0, 0, "g"), [10, 11, 12]),
+        (("b", 0, 0, "g", 1), 11),
+        (("b", 1, 0, 2), 40),
+        (("b", -2, -1, "g",  -3), 10),
+    ],
+)
+def test_deep_get_happy_path(nested_dict, keys, expected):
+    """Verify that deep_get returns the expected value for valid key chains."""
+    assert deep_get(nested_dict, *keys) == expected
+
+
+def test_deep_get_none_input():
+    """Calling with ``None`` as the mapping should return ``None``."""
+    assert deep_get(None) is None
+
+
+def test_deep_get_missing_key(nested_dict):
+    """Missing intermediate keys must short‑circuit to ``None``."""
+    assert deep_get(nested_dict, "a", "missing", "key") is None
+
+
+def test_deep_get_non_mapping_intermediate():
+    """If an intermediate value isn’t a mapping, the function should stop."""
+    # Here "x" resolves to an int (42); further traversal is impossible.
+    assert deep_get({"root": {"x": 42}}, "root", "x", "anything") is None
+
+
+def test_deep_get_index_out_of_bound(nested_dict):
+    """If an index is larger than the list, deep_get should return None"""
+    assert deep_get(nested_dict, "b", 2) is None
+
+def test_deep_get_negative_index_out_of_bound(nested_dict):
+    """If an index is larger than the list, deep_get should return None"""
+    assert deep_get(nested_dict, "b", -3) is None
+
+def test_deep_get_str_return_str_on_success(nested_dict):
+    assert deep_get_str(nested_dict, "a", "y") == "leaf"
+
+def test_deep_get_str_return_none_on_failure(nested_dict):
+    assert deep_get_str(nested_dict, "c", "y") == None
+
+def test_deep_get_list_return_list_on_success(nested_dict):
+    assert deep_get_list(nested_dict, "b", 0, 0, "g", ) == [10, 11, 12]
+
+def test_deep_get_list_return_empty_list_on_failure(nested_dict):
+    assert deep_get_list(nested_dict, "c" ) == []
+
+def test_deep_get_dict_return_dict_on_success(nested_dict):
+    assert deep_get_dict(nested_dict, "a", "b", "c" ) == {"d": "A"}
+
+def test_deep_get_dict_return_empty_dict_on_failure(nested_dict):
+    assert deep_get_dict(nested_dict, "c" ) == {}

--- a/tests/test_episodeplug.py
+++ b/tests/test_episodeplug.py
@@ -1,0 +1,70 @@
+import pytest
+
+from nrkradio import EpisodePlug
+
+
+@pytest.fixture
+def episode_plug_response():
+    return {
+        "type": "episode",
+        "_links": {
+            "episode": "/programs/ABCDEFG12345678",
+            "mediaelement": "/mediaelement/ABCDEFG12345678",
+            "series": "/series/seriesname",
+            "season": "/series/seriesname/seasons/0/episodes",
+        },
+        "episode": {
+            "titles": {
+                "title": "Episode title",
+                "subtitle": "Episode subtitle",
+            },
+            "image": {
+                "id": "019c39ec-1deb-7ec7-989d-e11ad4024165",
+                "webImages": [
+                    {
+                        "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165fmIQECFtGh-Z6FOsEAclhA",
+                        "width": 300,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165xFzIdgDHG7yZ6FOsEAclhA",
+                        "width": 600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165g7wscWA5W0SZ6FOsEAclhA",
+                        "width": 960,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165g-lYjMeaUq6Z6FOsEAclhA",
+                        "width": 1280,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165JcUtlKdzziiZ6FOsEAclhA",
+                        "width": 1600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165Wlj7LVBuuqOZ6FOsEAclhA",
+                        "width": 1920,
+                    },
+                ],
+            },
+            "duration": "PT57M",
+            "series": {"titles": {"title": "Series title"}},
+        },
+    }
+
+
+def test_init(episode_plug_response):
+
+    episode_plug: EpisodePlug = EpisodePlug(episode_plug_response)
+
+    assert episode_plug.id == None
+    assert episode_plug.title == "Series title: Episode title: Episode subtitle"
+    assert episode_plug.manifest_url == "/programs/ABCDEFG12345678"
+    assert (
+        episode_plug.thumb
+        == "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165fmIQECFtGh-Z6FOsEAclhA"
+    )
+    assert (
+        episode_plug.fanart
+        == "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165Wlj7LVBuuqOZ6FOsEAclhA"
+    )

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest import mock
+
+from requests import HTTPError
+from nrk import get
+
+
+@pytest.fixture
+def mock_session_success():
+    class _Response:
+        def __init__(self, path: str):
+            if len(path.split("&")) > 1:
+                self.params = True
+            else:
+                self.params = False
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            if self.params:
+                return {"C": "D"}
+            else:
+                return {"A": "B"}
+
+    with mock.patch("nrk.session") as myclass_mocked:
+        myclass_mocked.get.side_effect = _Response
+        yield myclass_mocked
+
+
+@pytest.fixture
+def mock_session_failure():
+    class _Response:
+        def __init__(self, path: str):
+            pass
+
+        def raise_for_status(self):
+            raise HTTPError
+
+        def json(self):
+            return None
+
+    with mock.patch("nrk.session") as myclass_mocked:
+        myclass_mocked.get.side_effect = _Response
+        yield myclass_mocked
+
+
+def test_get_success(mock_session_success):
+    response = get("a/b/c")
+    assert response == {"A": "B"}
+
+
+def test_get_with_parameter_success(mock_session_success):
+    response = get("a/b/c", "&c=true")
+    assert response == {"C": "D"}
+
+
+def test_get_httperror(mock_session_failure):
+    with pytest.raises(HTTPError):
+        response = get("a/b/c")
+
+
+def test_get_invalid_argument(mock_session_success):
+    with pytest.raises(ValueError, match="params must start with &"):
+        response = get("a/b/c", "abc")

--- a/tests/test_map_type_to_class.py
+++ b/tests/test_map_type_to_class.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest import mock
+from enum import Enum
+from nrkradio import Channel, Page, Podcast, PodcastEpisode, Season, Section, Series, StandaloneProgram, Type, map_type_to_class
+
+@pytest.fixture
+def mock_type():
+    class Type(Enum):
+        MISSINGTYPE = "missingtype"
+
+    with mock.patch("nrkradio.Type", return_value=Type ) as mocked:
+        yield mocked
+
+
+
+@pytest.mark.parametrize(
+    argnames="type,expected_plug_class",
+    argvalues=[
+        (Type.CHANNEL, Channel),
+        (Type.PAGE, Page),
+        (Type.PODCAST, Podcast),
+        (Type.PODCASTEPISODE, PodcastEpisode),
+        (Type.SEASON, Season),
+        (Type.SECTION, Section),
+        (Type.SERIES, Series),
+        (Type.STANDALONEPROGRAM, StandaloneProgram)
+    ],
+    ids=["Channel", "Page", "Podcast", "PodcastEpisode", "Season", "Section", "Series", "StandaloneProgram"],
+)
+def test_map_type_to_class(type, expected_plug_class):
+    item_class = map_type_to_class(type)
+
+    assert item_class == expected_plug_class
+
+def test_map_invalid_type_to_class():
+    item_type = "invalid_type"
+    with pytest.raises(ValueError, match=f"No type found for: {item_type}"):
+        _ = map_type_to_class(item_type)
+
+def test_map_missing_type_to_class(mock_type):
+    item_type = "missingtype"
+    with pytest.raises(ValueError, match=f"No class found for: {item_type}"):
+        _ = map_type_to_class(item_type)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,0 +1,187 @@
+import pytest
+from unittest import mock
+
+from nrkradio import Page
+
+
+@pytest.fixture
+def full_page_response():
+    """A minimal response containing an ``included`` block."""
+    return {
+        "title": "Placeholder Page Title",
+        "sections": [
+            {
+                "included": {
+                    "title": "Section 1 Title",
+                    "plugs": [
+                        {
+                            "type": "podcastEpisode",
+                            "_links": {
+                                "podcastEpisode": "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf",
+                                "podcast": "/podcasts/podcastname",
+                                "audioDownload": "https://example.com/fil/podcastname/e491a7cb-af50-411f-b91a-a292021ec8cf_1_ID192MP3.mp3",
+                            },
+                            "podcastEpisode": {
+                                "titles": {
+                                    "title": "Podcast episode title",
+                                    "subtitle": "Podcast episode subtitle",
+                                },
+                                "duration": "PT28M3S",
+                                "imageUrl": "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c",
+                                "podcast": {"titles": {"title": "Podcast Title"}},
+                            },
+                        }
+                    ],
+                }
+            },
+            {
+                "included": {
+                    "title": "Section 2 Title",
+                    "plugs": [
+                        {
+                            "type": "channel",
+                            "_links": {"channel": "/mediaelement/channelname"},
+                            "channel": {
+                                "titles": {"title": "Channel title"},
+                                "image": {
+                                    "id": "019c39da-d036-70f5-9c30-9c7179f233ff",
+                                    "webImages": [
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff7H9WHy0d_QEvZ41HevX4tQ",
+                                            "width": 300,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffnptQAWmTl0QvZ41HevX4tQ",
+                                            "width": 600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffNE58lEqQAswvZ41HevX4tQ",
+                                            "width": 960,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffktYCmVGM_QUvZ41HevX4tQ",
+                                            "width": 1280,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffBdvbxUqgPHYvZ41HevX4tQ",
+                                            "width": 1600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff1ean57gyYhQvZ41HevX4tQ",
+                                            "width": 1920,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                }
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def partial_pageoverview_response():
+    return {
+        "id": "page-1-id",
+        "title": "Page 1 title",
+        "image": {
+            "id": "019c3cdd-6e05-7b5e-829b-6a4c9ddfa4ce",
+            "webImages": [
+                {
+                    "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cegKgTsPQJZae1rsNo2OAiGQ",
+                    "width": 300,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4ce7hh1hLWNswW1rsNo2OAiGQ",
+                    "width": 600,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4ceKyiD_s3EMtS1rsNo2OAiGQ",
+                    "width": 960,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cezN14j0NRrlu1rsNo2OAiGQ",
+                    "width": 1920,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cefOZP8gWnC_e1rsNo2OAiGQ",
+                    "width": 2560,
+                },
+            ],
+        },
+        "imageSquare": {
+            "id": "019c3cdd-c545-778e-a526-4c28dd1edfc6",
+            "webImages": [
+                {
+                    "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6UG6zSk2546ubgVx8rcIBLw",
+                    "width": 300,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6uC694XTUenmbgVx8rcIBLw",
+                    "width": 600,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6Y8ZP28eolNqbgVx8rcIBLw",
+                    "width": 960,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6tIxagAXA9aWbgVx8rcIBLw",
+                    "width": 1920,
+                },
+                {
+                    "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6adV_E5T3IambgVx8rcIBLw",
+                    "width": 2560,
+                },
+            ],
+        },
+        "_links": {"self": {"href": "/radio/pages/page-1-id"}},
+    }
+
+
+def test_init_full_page(full_page_response):
+    page_id = "page-id"
+    page = Page(page_id, full_page_response)
+    assert page.id == page_id
+    assert len(page.children) == 2
+    assert [child.id for child in page.children] == ["0", "1"]
+    assert [child.title for child in page.children] == [
+        "Section 1 Title",
+        "Section 2 Title",
+    ]
+    assert page.thumb == None
+    assert page.fanart == None
+
+
+def test_init_partial_pageoverview(partial_pageoverview_response):
+    page_id = "page-id"
+    page = Page(page_id, partial_pageoverview_response)
+    assert page.id == page_id
+    assert len(page.children) == 0
+    assert (
+        page.thumb
+        == "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cegKgTsPQJZae1rsNo2OAiGQ"
+    )
+    assert (
+        page.fanart
+        == "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cefOZP8gWnC_e1rsNo2OAiGQ"
+    )
+
+
+def test_from_url_success():
+    with mock.patch("nrk.get", return_value=full_page_response) as mocked_get:
+        page_id = "page-id"
+        page = Page.from_url(f"/radio/pages/{page_id}")
+
+        mocked_get.assert_called_once_with(f"/radio/pages/{page_id}")
+
+        assert page.id == page_id
+
+
+def test_from_url_invalid_format():
+    """
+    An incorrectly formatted URL should raise ``ValueError``.
+    """
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        _ = Page.from_url("/radio/pages")

--- a/tests/test_pagesoverview.py
+++ b/tests/test_pagesoverview.py
@@ -1,0 +1,146 @@
+from unittest import mock
+import pytest
+
+from nrk import Base
+from nrkradio import PagesOverview
+
+
+@pytest.fixture
+def pages():
+    return {
+        "pages": [
+            {
+                "id": "page-1-id",
+                "title": "Page 1 title",
+                "image": {
+                    "id": "019c3cdd-6e05-7b5e-829b-6a4c9ddfa4ce",
+                    "webImages": [
+                        {
+                            "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cegKgTsPQJZae1rsNo2OAiGQ",
+                            "width": 300,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4ce7hh1hLWNswW1rsNo2OAiGQ",
+                            "width": 600,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4ceKyiD_s3EMtS1rsNo2OAiGQ",
+                            "width": 960,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cezN14j0NRrlu1rsNo2OAiGQ",
+                            "width": 1920,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cefOZP8gWnC_e1rsNo2OAiGQ",
+                            "width": 2560,
+                        },
+                    ],
+                },
+                "imageSquare": {
+                    "id": "019c3cdd-c545-778e-a526-4c28dd1edfc6",
+                    "webImages": [
+                        {
+                            "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6UG6zSk2546ubgVx8rcIBLw",
+                            "width": 300,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6uC694XTUenmbgVx8rcIBLw",
+                            "width": 600,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6Y8ZP28eolNqbgVx8rcIBLw",
+                            "width": 960,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6tIxagAXA9aWbgVx8rcIBLw",
+                            "width": 1920,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-c545-778e-a526-4c28dd1edfc6adV_E5T3IambgVx8rcIBLw",
+                            "width": 2560,
+                        },
+                    ],
+                },
+                "_links": {"self": {"href": "/radio/pages/page-1-id"}},
+            },
+            {
+                "id": "page-2-id",
+                "title": "Page 2 title",
+                "image": {
+                    "id": "019c3cdd-f815-7095-bcd6-4f83c47b2fc3",
+                    "webImages": [
+                        {
+                            "uri": "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3hjIvsjAz3RBv3M7W1gol9w",
+                            "width": 300,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3fZky2QUeIQVv3M7W1gol9w",
+                            "width": 600,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3vxJrCrGtMFZv3M7W1gol9w",
+                            "width": 960,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3s-tlf2PK7ixv3M7W1gol9w",
+                            "width": 1920,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3OWkkME37HaNv3M7W1gol9w",
+                            "width": 2560,
+                        },
+                    ],
+                },
+                "imageSquare": {
+                    "id": "019c3cde-1bcd-7b86-a26c-01cfd54d9eac",
+                    "webImages": [
+                        {
+                            "uri": "https://example.com/019c3cde-1bcd-7b86-a26c-01cfd54d9eacWQujeV-P_F0K65LK4HQ9qQ",
+                            "width": 300,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cde-1bcd-7b86-a26c-01cfd54d9eachf3qrMP7znwK65LK4HQ9qQ",
+                            "width": 600,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cde-1bcd-7b86-a26c-01cfd54d9eacYc1bu5OoeFYK65LK4HQ9qQ",
+                            "width": 960,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cde-1bcd-7b86-a26c-01cfd54d9eacBuVY-q0fdRgK65LK4HQ9qQ",
+                            "width": 1920,
+                        },
+                        {
+                            "uri": "https://example.com/019c3cde-1bcd-7b86-a26c-01cfd54d9eac6iL1U-Bp6XAK65LK4HQ9qQ",
+                            "width": 2560,
+                        },
+                    ],
+                },
+                "_links": {"self": {"href": "/radio/pages/page-2-id"}},
+            },
+        ],
+        "_links": {"self": {"href": "/radio/pages"}},
+    }
+
+
+def test_init(pages):
+    with mock.patch("nrk.get", return_value=pages) as mocked_get:
+        pages_overview = PagesOverview()
+
+        mocked_get.assert_called_once_with("/radio/pages")
+
+        assert pages_overview.manifest_url == "/radio/pages"
+
+        assert len(pages_overview.children) == 2
+        assert all(isinstance(p, Base) for p in pages_overview.children)
+        # The titles of the children should match the titles in the response
+        assert [p.id for p in pages_overview.children] == ["page-1-id", "page-2-id"]
+        assert [p.thumb for p in pages_overview.children] == [
+            "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cegKgTsPQJZae1rsNo2OAiGQ",
+            "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3hjIvsjAz3RBv3M7W1gol9w",
+        ]
+        assert [p.fanart for p in pages_overview.children] == [
+            "https://example.com/019c3cdd-6e05-7b5e-829b-6a4c9ddfa4cefOZP8gWnC_e1rsNo2OAiGQ",
+            "https://example.com/019c3cdd-f815-7095-bcd6-4f83c47b2fc3OWkkME37HaNv3M7W1gol9w"
+        ]

--- a/tests/test_plug_factory.py
+++ b/tests/test_plug_factory.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+
+import pytest
+
+from nrkradio import (
+    BasePlug,
+    ChannelPlug,
+    EpisodePlug,
+    PodcastEpisodePlug,
+    PodcastPlug,
+    SeriesPlug,
+    StandaloneProgramPlug,
+    plug_factory,
+)
+
+
+@pytest.fixture
+def response(request) -> dict[str, Any]:
+    data = request.param
+
+    return {"type": data}
+
+
+class PlugStub(object):
+    def __init__(self, response) -> None:
+        self.response = response
+
+
+@pytest.mark.parametrize(
+    argnames="response,expected_plug_class",
+    argvalues=[
+        ("channel", ChannelPlug),
+        ("podcastEpisode", PodcastEpisodePlug),
+        ("standaloneProgram", StandaloneProgramPlug),
+        ("podcast", PodcastPlug),
+        ("episode", EpisodePlug),
+        ("series", SeriesPlug),
+    ],
+    ids=["channel", "podcastEpisode", "standaloneProgram", "podcast", "episode", "series"],
+    indirect=["response"],
+)
+def test_plug_factory_success(response: dict[str, Any], expected_plug_class):
+
+    plug: BasePlug = plug_factory(response)
+    assert isinstance(plug, expected_plug_class), (
+        f"Expected {expected_plug_class.__name__}, " f"but got {type(plug).__name__}"
+    )
+
+def test_plug_factory_no_type():
+    response = {}
+    with pytest.raises(ValueError, match="No type found in plug"):
+        _ = plug_factory(response)
+
+def test_plug_factory_unsupported_plug():
+    response = { "type": "unsupported"
+    }
+    with pytest.raises(ValueError, match="Unsupported plug type: unsupported"):
+        _ = plug_factory(response)

--- a/tests/test_podcast.py
+++ b/tests/test_podcast.py
@@ -1,0 +1,423 @@
+import pytest
+from unittest import mock
+
+from nrkradio import Podcast, Season
+
+
+@pytest.fixture
+def podcast_manifest():
+    return {
+        "_links": {
+            "self": {"href": "/radio/catalog/podcast/podcast-name"},
+            "seasons": [
+                {
+                    "name": "202602",
+                    "href": "/radio/catalog/podcast/podcast-name/seasons/202602",
+                    "title": "Februar 2026",
+                },
+                {
+                    "name": "202601",
+                    "href": "/radio/catalog/podcast/podcast-name/seasons/202601",
+                    "title": "Januar 2026",
+                },
+            ],
+            "userData": {
+                "href": "/radio/userdata/podcast/podcast-name/{userId}",
+                "templated": True,
+            },
+            "favourite": {
+                "href": "/radio/userdata/{userId}/favourites/podcast/podcast-name",
+                "templated": True,
+            },
+            "episodes": {"href": "/radio/catalog/podcast/podcast-name/episodes"},
+            "highlightedEpisode": {
+                "href": "/radio/userdata/{userId}/progress/podcast/podcast-name/highlightedProgram",
+                "templated": True,
+            },
+            "primaryAction": {
+                "href": "/radio/userdata/{userId}/primaryaction/podcasts/podcast-name",
+                "templated": True,
+            },
+            "share": {"href": "https://example.com/podkast/podcast-name"},
+        },
+        "seriesType": "standard",
+        "type": "podcast",
+        "seasonDisplayType": "month",
+        "navigationLinks": [],
+        "series": {
+            "id": "podcast-name",
+            "titles": {
+                "title": "Podcast title",
+                "subtitle": "Podcast subtitle",
+            },
+            "category": {"id": "category-id", "name": "category name"},
+            "image": [
+                {
+                    "url": "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b3112EXYyR0PkRL8goQ9CQfoZA",
+                    "width": 300,
+                },
+                {
+                    "url": "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311ROi83L76Jtf8goQ9CQfoZA",
+                    "width": 600,
+                },
+                {
+                    "url": "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311outL2MSyoo_8goQ9CQfoZA",
+                    "width": 960,
+                },
+                {
+                    "url": "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311hq1QPfWftqn8goQ9CQfoZA",
+                    "width": 1280,
+                },
+                {
+                    "url": "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311L_pTSxw2erj8goQ9CQfoZA",
+                    "width": 1600,
+                },
+                {
+                    "url": "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311Vn6Zf67d6fj8goQ9CQfoZA",
+                    "width": 1920,
+                },
+            ],
+            "backdropImage": [
+                {
+                    "url": "https://example.com/019c46e6-a6fb-73bb-a48c-325d8550360120DJl9T5Z7eKh112wPtdNQ",
+                    "width": 300,
+                },
+                {
+                    "url": "https://example.com/019c46e6-a6fb-73bb-a48c-325d85503601iviNnt34A5KKh112wPtdNQ",
+                    "width": 600,
+                },
+                {
+                    "url": "https://example.com/019c46e6-a6fb-73bb-a48c-325d85503601epEmdt6eczGKh112wPtdNQ",
+                    "width": 960,
+                },
+                {
+                    "url": "https://example.com/019c46e6-a6fb-73bb-a48c-325d85503601u-G0Drs76n2Kh112wPtdNQ",
+                    "width": 1280,
+                },
+                {
+                    "url": "https://example.com/019c46e6-a6fb-73bb-a48c-325d85503601poZaQNr3sLeKh112wPtdNQ",
+                    "width": 1600,
+                },
+                {
+                    "url": "https://example.com/019c46e6-a6fb-73bb-a48c-325d85503601jejHSZ_udh6Kh112wPtdNQ",
+                    "width": 1920,
+                },
+            ],
+            "posterImage": [],
+            "squareImage": [
+                {
+                    "url": "https://example.com/019c46e7-042e-756f-8f9a-bce6c154e991F6HS86WlEctR-3he47nZKg",
+                    "width": 300,
+                },
+                {
+                    "url": "https://example.com/019c46e7-042e-756f-8f9a-bce6c154e991S0a4RSlk-vlR-3he47nZKg",
+                    "width": 600,
+                },
+                {
+                    "url": "https://example.com/019c46e7-042e-756f-8f9a-bce6c154e991b4OLFT2BFmxR-3he47nZKg",
+                    "width": 960,
+                },
+                {
+                    "url": "https://example.com/019c46e7-042e-756f-8f9a-bce6c154e991Vb8FKln4GSpR-3he47nZKg",
+                    "width": 1280,
+                },
+                {
+                    "url": "https://example.com/019c46e7-042e-756f-8f9a-bce6c154e991jM4xS3AUNipR-3he47nZKg",
+                    "width": 1600,
+                },
+            ],
+        },
+        "_embedded": {
+            "episodes": {
+                "_links": {
+                    "self": {
+                        "href": "/radio/catalog/podcast/podcast-name/episodes?page=1&pageSize=20&sort=desc"
+                    },
+                    "next": {
+                        "href": "/radio/catalog/podcast/podcast-name/episodes?page=2&pageSize=20&sort=desc"
+                    },
+                    "progresses": [
+                        {
+                            "href": "/radio/userdata/{userId}/progress/podcast/podcast-name?contentIds=H4sIAAAAAAAAAyXRS64tIQgF0AmdnSiFCKOpyMdWzb_9wrtNVoi44XstMinKIR4HXKSwpEB5gxTpc37faytjpAlGuYEtAhYjYdIgFvG_LdmIR14sORs8faEBeRto-ir-fe9hUjY72LMKvG3hKBvsNMxt69bve-dcLiQHe8UESxXMhSCnYUkVzW6rK_uS4MndEfLCZV-QNFDl9W5bfI7lUmy7B7x3oQFLG3Tvuvr7Xp5r1faBnFbglAVbteGjoeshv--tJ-5mH7hndhsZ9G6GjwZKMs1-TZzrzgGyTuo10YA5GtxrmvXe0pRKFZSPg8MFDVBtsHD5G5puRHYwVB9wTUUD7DR4TaXemw89OVbgRFxw7IMGrGiI2EdW37SG8ngKSkrg5xpUeeCphq5vR5hEZSYM2iJgCsMpMwg3OIV5D6WrHEEDxFTg1QvhCNBoyEUm9_e9eiNz97dIB3jzhWZuxG0Ym2910vSteuaDSlbwtYKrHsynYV6r6x1BnjVKFMPvBotf-BoF0QYVv7H_bjr1-ELSc8BzB2zqga8GmztG_QOgS0gNCwMAAA",
+                            "templated": True,
+                        }
+                    ],
+                },
+                "seriesType": "standard",
+                "_embedded": {
+                    "episodes": [
+                        {
+                            "_links": {
+                                "self": {
+                                    "href": "/radio/catalog/podcast/podcast-name/episodes/l_019c46e7-582a-76cb-8b53-c0e2abea7bfc"
+                                },
+                                "playback": {
+                                    "href": "/playback/metadata/podcast/podcast-name/l_019c46e7-582a-76cb-8b53-c0e2abea7bfc"
+                                },
+                                "series": {
+                                    "name": "podcast-name",
+                                    "href": "/radio/catalog/podcast/podcast-name",
+                                    "title": "Podcast title",
+                                },
+                                "season": {
+                                    "name": "202602",
+                                    "title": "Februar 2026",
+                                    "href": "/radio/catalog/podcast/podcast-name/seasons/202602",
+                                    "seriesType": "standard",
+                                },
+                                "favourite": {
+                                    "href": "/radio/userdata/{userId}/favourites/podcast/podcast-name",
+                                    "templated": True,
+                                },
+                                "share": {
+                                    "href": "https://example.com/podkast/podcast-name/l_019c46e7-582a-76cb-8b53-c0e2abea7bfc"
+                                },
+                                "progress": {
+                                    "href": "/radio/userdata/{userId}/progress/podcastepisode/podcast-name|l_019c46e7-582a-76cb-8b53-c0e2abea7bfc",
+                                    "templated": True,
+                                },
+                                "recommendations": {
+                                    "href": "/radio/recommendations/podcast-name?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                                    "templated": True,
+                                },
+                            },
+                            "id": "019c46e7-dd0b-723b-ae9e-8a4f66f20479",
+                            "episodeId": "l_019c46e7-582a-76cb-8b53-c0e2abea7bfc",
+                            "titles": {
+                                "title": "Podcast episode 1 title",
+                                "subtitle": "Podcast episode 1 subtitle",
+                            },
+                            "originalTitle": "Podcast title",
+                            "image": [
+                                {
+                                    "url": "https://example.com/019c46e8-8257-7b50-a629-70def026f329wifA9oZ07Pu36ahKZaGpwDQ",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-8257-7b50-a629-70def026f329w30RRfaa-vzT6ahKZaGpwDQ",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-8257-7b50-a629-70def026f329wv0ZFsoLm_oT6ahKZaGpwDQ",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-8257-7b50-a629-70def026f329whiBRcbzHO9H6ahKZaGpwDQ",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-8257-7b50-a629-70def026f329wiojpZwMn5ez6ahKZaGpwDQ",
+                                    "width": 1600,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-8257-7b50-a629-70def026f329wZaA8XwWw5fH6ahKZaGpwDQ",
+                                    "width": 1920,
+                                },
+                            ],
+                            "squareImage": [
+                                {
+                                    "url": "https://example.com/019c46e8-ab14-7d94-b70a-a8f55219ae72wzDN29YyRVDhPwX_EFNfIA",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-ab14-7d94-b70a-a8f55219ae729lbin9X3mWThPwX_EFNfIA",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-ab14-7d94-b70a-a8f55219ae72s4RlQmo2kVfhPwX_EFNfIA",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-ab14-7d94-b70a-a8f55219ae72yoN9Qmgn5r7hPwX_EFNfIA",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e8-ab14-7d94-b70a-a8f55219ae72d-G_kab5O1nhPwX_EFNfIA",
+                                    "width": 1600,
+                                },
+                            ],
+                            "duration": "PT15M2S",
+                            "date": "2026-02-10T08:00:00+01:00",
+                            "durationInSeconds": 902,
+                            "usageRights": {
+                                "from": {
+                                    "date": "2026-02-10T08:00:00+01:00",
+                                    "displayValue": "10. februar 2026 kl. 08:00",
+                                },
+                                "to": {
+                                    "date": "9999-12-22T00:59:59+01:00",
+                                    "displayValue": "Alltid tilgjengelig",
+                                },
+                                "geoBlock": {
+                                    "isGeoBlocked": False,
+                                    "displayValue": "Verden",
+                                },
+                            },
+                            "availability": {"status": "available", "hasLabel": False},
+                            "badges": [{"label": "Ny", "type": "new"}],
+                            "category": {"id": "category-id", "name": "category name"},
+                        },
+                        {
+                            "_links": {
+                                "self": {
+                                    "href": "/radio/catalog/podcast/podcast-name/episodes/l_019c46e9-065f-7c87-bb14-f4c2f62c1270"
+                                },
+                                "playback": {
+                                    "href": "/playback/metadata/podcast/podcast-name/l_019c46e9-065f-7c87-bb14-f4c2f62c1270"
+                                },
+                                "series": {
+                                    "name": "podcast-name",
+                                    "href": "/radio/catalog/podcast/podcast-name",
+                                    "title": "Podcast title",
+                                },
+                                "season": {
+                                    "name": "202602",
+                                    "title": "Februar 2026",
+                                    "href": "/radio/catalog/podcast/podcast-name/seasons/202602",
+                                    "seriesType": "standard",
+                                },
+                                "favourite": {
+                                    "href": "/radio/userdata/{userId}/favourites/podcast/podcast-name",
+                                    "templated": True,
+                                },
+                                "share": {
+                                    "href": "https://example.com/podkast/podcast-name/l_019c46e9-065f-7c87-bb14-f4c2f62c1270"
+                                },
+                                "progress": {
+                                    "href": "/radio/userdata/{userId}/progress/podcastepisode/podcast-name|l_019c46e9-065f-7c87-bb14-f4c2f62c1270",
+                                    "templated": True,
+                                },
+                                "recommendations": {
+                                    "href": "/radio/recommendations/podcast-name?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                                    "templated": True,
+                                },
+                            },
+                            "id": "16ded18f75e1e98452a320b4e00a7ff6",
+                            "episodeId": "l_019c46e9-065f-7c87-bb14-f4c2f62c1270",
+                            "titles": {
+                                "title": "Podcast episode 2 title",
+                                "subtitle": "Podcast episode 2 subtitle",
+                            },
+                            "originalTitle": "Podcast title",
+                            "image": [
+                                {
+                                    "url": "https://example.com/019c46e9-e9c8-7605-b642-d8f501927538FlzFicTfH4iSel3Vp_qanQ",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e9-e9c8-7605-b642-d8f501927538bI50ao6OeY-Sel3Vp_qanQ",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e9-e9c8-7605-b642-d8f501927538BSqjZUTmi4WSel3Vp_qanQ",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e9-e9c8-7605-b642-d8f501927538JUYrlDMGD_6Sel3Vp_qanQ",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e9-e9c8-7605-b642-d8f501927538KPDGtZZdTT-Sel3Vp_qanQ",
+                                    "width": 1600,
+                                },
+                                {
+                                    "url": "https://example.com/019c46e9-e9c8-7605-b642-d8f501927538uxL4fOnJeLiSel3Vp_qanQ",
+                                    "width": 1920,
+                                },
+                            ],
+                            "squareImage": [
+                                {
+                                    "url": "https://example.com/019c46ea-1a12-714e-a8c2-3cc37225e3aa7P9j0IqX7hzlQlJdukWb7A",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c46ea-1a12-714e-a8c2-3cc37225e3aaLZR7Z3VMSLblQlJdukWb7A",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c46ea-1a12-714e-a8c2-3cc37225e3aaZAtpD87XlwHlQlJdukWb7A",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c46ea-1a12-714e-a8c2-3cc37225e3aaWL4cikhwZA_lQlJdukWb7A",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c46ea-1a12-714e-a8c2-3cc37225e3aaVYjiK16KXtPlQlJdukWb7A",
+                                    "width": 1600,
+                                },
+                            ],
+                            "duration": "PT15M9S",
+                            "date": "2026-02-09T08:00:00+01:00",
+                            "durationInSeconds": 909,
+                            "usageRights": {
+                                "from": {
+                                    "date": "2026-02-09T08:00:00+01:00",
+                                    "displayValue": "9. februar 2026 kl. 08:00",
+                                },
+                                "to": {
+                                    "date": "9999-12-22T00:59:59+01:00",
+                                    "displayValue": "Alltid tilgjengelig",
+                                },
+                                "geoBlock": {
+                                    "isGeoBlocked": False,
+                                    "displayValue": "Verden",
+                                },
+                            },
+                            "availability": {"status": "available", "hasLabel": False},
+                            "badges": [],
+                            "category": {"id": "category-id", "name": "category name"},
+                        },
+                    ]
+                },
+            }
+        },
+    }
+
+
+def test_init(podcast_manifest):
+    podcast_series_id = "podcast-name"
+    podcast = Podcast(podcast_series_id, podcast_manifest)
+
+    assert podcast.title == "Podcast title"
+    assert podcast.manifest_url == f"/radio/catalog/podcast/{podcast_series_id}"
+    assert podcast.thumb == "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b3112EXYyR0PkRL8goQ9CQfoZA"
+    assert podcast.fanart == "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311Vn6Zf67d6fj8goQ9CQfoZA"
+    assert len(podcast.children) == 2
+    assert [isinstance(child, Season) for child in podcast.children] == [True, True]
+    assert [child.title for child in podcast.children] == [
+        "Februar 2026",
+        "Januar 2026",
+    ]
+    assert [child.manifest_url for child in podcast.children] == [
+        "/radio/catalog/podcast/podcast-name/seasons/202602",
+        "/radio/catalog/podcast/podcast-name/seasons/202601",
+    ]
+    assert [child.thumb for child in podcast.children] == [ None, None]
+    assert [child.fanart for child in podcast.children] == [ None, None]
+
+
+def test_from_url_success(podcast_manifest):
+    podcast_series_id = "podcast-name"
+    with mock.patch("nrk.get", return_value=podcast_manifest) as mocked_get:
+        podcast = Podcast.from_url(f"/podcasts/{podcast_series_id}")
+
+        # ---- Assertions about the call ------------------------------
+        mocked_get.assert_called_once_with(
+            f"/radio/catalog/podcast/{podcast_series_id}"
+        )
+
+        # ---- Assertions about the created Podcast -------------------
+        assert podcast.id == podcast_series_id
+        assert podcast.title == "Podcast title"
+        assert podcast.manifest_url == f"/radio/catalog/podcast/{podcast_series_id}"
+        assert podcast.thumb == "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b3112EXYyR0PkRL8goQ9CQfoZA"
+        assert podcast.fanart == "https://example.com/019c46e6-4c9b-74f2-b0bc-20693718b311Vn6Zf67d6fj8goQ9CQfoZA"
+
+        assert len(podcast.children) == 2
+
+def test_from_url_wrong_format():
+    
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        _ = Podcast.from_url("/podcasts/podcast-name/season/season1")
+    

--- a/tests/test_podcastepisode.py
+++ b/tests/test_podcastepisode.py
@@ -1,0 +1,333 @@
+from unittest import mock
+import pytest
+
+from nrk import deep_get_list
+from nrkradio import PodcastEpisode
+
+
+@pytest.fixture
+def podcastepisode_manifest():
+    return {
+        "_links": {
+            "self": {
+                "href": "/playback/manifest/podcast/l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+            },
+            "metadata": {
+                "href": "/playback/metadata/podcast/l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+                "name": "metadata",
+            },
+        },
+        "id": "l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+        "playability": "playable",
+        "streamingMode": "onDemand",
+        "availability": {
+            "information": "",
+            "isGeoBlocked": False,
+            "onDemand": {
+                "from": "2023-05-03T04:04:00Z",
+                "to": "9999-12-31T23:59:59.9999999Z",
+                "hasRightsNow": True,
+            },
+            "live": None,
+            "externalEmbeddingAllowed": True,
+        },
+        "statistics": {
+            "scores": None,
+            "ga": {
+                "dimension1": "podcast:l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+                "dimension2": "Podcastepisode Title",
+                "dimension3": "",
+                "dimension4": "",
+                "dimension5": "",
+                "dimension10": "podcast:l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+                "dimension21": "podcast_episode_title",
+                "dimension22": "",
+                "dimension23": "",
+                "dimension25": "audio",
+                "dimension26": "ondemand",
+                "dimension29": "other/generic_hls",
+                "dimension36": "other-generichls|mp3|notapplicable|notapplicable|podcast|telenor|world|podcast-cdn|europeaneconomicarea|notapplicable|none|notapplicable|notapplicable",
+            },
+            "conviva": None,
+            "luna": {
+                "config": {"beacon": "https://example.com/akamai-beacon.xml"},
+                "data": {
+                    "title": "",
+                    "device": "",
+                    "playerId": "",
+                    "deliveryType": "",
+                    "playerInfo": "",
+                    "cdnName": "Podcast-Cdn",
+                },
+            },
+            "qualityOfExperience": {
+                "clientName": "other-generichls",
+                "cdnName": "podcast-cdn",
+                "streamingFormat": "mp3",
+                "segmentLength": "n/a",
+                "assetType": "ondemand",
+                "correlationId": "019c3d64-585c-75fc-bda2-3cc5e43202be",
+            },
+            "snowplow": {"source": "podcast"},
+        },
+        "playable": {
+            "endSequenceStartTime": None,
+            "duration": "PT35M10S",
+            "assets": [
+                {
+                    "url": "https://example.com/fil/podcast_series_name/019c3d61-c741-7d7f-bb99-84d17abd0a70_0_ID192MP3.mp3",
+                    "format": "MP3",
+                    "mimeType": "audio/mp3",
+                    "encrypted": False,
+                    "encryptionScheme": "none",
+                }
+            ],
+            "liveBuffer": None,
+            "subtitles": [],
+            "thumbnails": [],
+        },
+        "nonPlayable": None,
+        "displayAspectRatio": None,
+        "sourceMedium": "audio",
+    }
+
+
+@pytest.fixture
+def podcastepisode_metadata():
+    return {
+        "_links": {
+            "self": {
+                "href": "/playback/metadata/podcast/l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+            },
+            "manifests": [
+                {
+                    "href": "/playback/manifest/podcast/l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+                    "name": "default",
+                }
+            ],
+            "next": None,
+            "nextLinks": None,
+            "progress": {
+                "templated": True,
+                "href": "/radio/userdata/{userId}/progress/podcastepisode/podcast_series_name|l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+            },
+            "personalizedNext": {
+                "templated": True,
+                "href": "/radio/userdata/{userId}/upnext/podcastepisode/podcast_series_name|l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+            },
+        },
+        "id": "l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+        "playability": "playable",
+        "streamingMode": "onDemand",
+        "duration": "PT35M10S",
+        "legalAge": {
+            "legalReference": "LOV2015-02-06-7",
+            "body": {
+                "status": "rated",
+                "rating": {
+                    "code": "A",
+                    "displayAge": "A",
+                    "displayValue": "Tillatt for alle",
+                },
+            },
+        },
+        "availability": {
+            "information": "",
+            "isGeoBlocked": False,
+            "onDemand": {
+                "from": "2023-05-03T04:04:00Z",
+                "to": "9999-12-31T23:59:59.9999999Z",
+                "hasRightsNow": True,
+            },
+            "live": None,
+            "externalEmbeddingAllowed": True,
+        },
+        "preplay": {
+            "titles": {
+                "title": "Podcastepisode title",
+                "subtitle": "Podcastepisode subtitle",
+            },
+            "description": "",
+            "poster": {
+                "images": [
+                    {
+                        "url": "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9oo1D8Cc8qQobqnXx559TCA",
+                        "pixelWidth": 300,
+                    },
+                    {
+                        "url": "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9Okb-AJQoJ28bqnXx559TCA",
+                        "pixelWidth": 600,
+                    },
+                    {
+                        "url": "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9dcYN6hp4DCobqnXx559TCA",
+                        "pixelWidth": 960,
+                    },
+                    {
+                        "url": "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9dmcl-jCds8kbqnXx559TCA",
+                        "pixelWidth": 1280,
+                    },
+                    {
+                        "url": "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9BdL8MC7rWP8bqnXx559TCA",
+                        "pixelWidth": 1920,
+                    },
+                ]
+            },
+            "squarePoster": {
+                "images": [
+                    {
+                        "url": "https://example.com/019c3d65-5181-7a79-a986-346df9fad9395krhowpl_K75AFgevbkifA",
+                        "pixelWidth": 300,
+                    },
+                    {
+                        "url": "https://example.com/019c3d65-5181-7a79-a986-346df9fad939VklepdyTHWH5AFgevbkifA",
+                        "pixelWidth": 600,
+                    },
+                    {
+                        "url": "https://example.com/019c3d65-5181-7a79-a986-346df9fad939sDGDFSs5ejX5AFgevbkifA",
+                        "pixelWidth": 960,
+                    },
+                    {
+                        "url": "https://example.com/019c3d65-5181-7a79-a986-346df9fad939GqLg4BBTM2D5AFgevbkifA",
+                        "pixelWidth": 1280,
+                    },
+                ]
+            },
+            "indexPoints": [],
+        },
+        "displayAspectRatio": None,
+        "playable": {
+            "resolve": "/playback/manifest/podcast/l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+        },
+        "nonPlayable": None,
+        "interactionPoints": None,
+        "sourceMedium": "audio",
+        "skipDialogInfo": None,
+        "interaction": None,
+        "_embedded": {
+            "manifests": [
+                {
+                    "_links": {
+                        "self": {
+                            "href": "/playback/manifest/podcast/l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+                            "name": "default",
+                        }
+                    },
+                    "id": "l_019c3d5f-c860-7fa8-9f53-801dfafeec85",
+                    "availabilityLabel": "Av",
+                }
+            ],
+            "next": None,
+            "podcast": {
+                "_links": {
+                    "podcast": {
+                        "href": "/podcasts/podcast_series_name",
+                        "name": "podcast",
+                    }
+                },
+                "titles": {
+                    "title": "Podcastepisode title",
+                    "subtitle": "Podcastepisode subtitle",
+                },
+                "imageUrl": "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9PSkx2dkPf9UbqnXx559TCA",
+                "rssFeed": "https://example.com/program/podcast_series_name.rss",
+                "episodeCount": 7,
+            },
+            "podcastEpisode": {"clipId": None},
+        },
+    }
+
+
+def test_init(podcastepisode_metadata):
+    title = "Dummy title"
+    podcast_series_id = "podcast_series_name"
+    podcast_episode_id = "l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+    images = deep_get_list(podcastepisode_metadata, "preplay", "poster", "images")
+    podcastepisode = PodcastEpisode(title, podcast_series_id, podcast_episode_id, images)
+    assert podcastepisode.id == podcast_episode_id
+    assert podcastepisode.title == title
+    assert (
+        podcastepisode.manifest_url
+        == f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}"
+    )
+    assert podcastepisode.thumb == "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9oo1D8Cc8qQobqnXx559TCA"
+    assert podcastepisode.fanart == "https://example.com/019c3d64-ef42-7cfb-953c-1bda48e2e3b9BdL8MC7rWP8bqnXx559TCA"
+
+
+def test_from_url_from_season_success(podcastepisode_metadata):
+
+    podcast_series_id = "podcast_series_name"
+    podcast_episode_id = "l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+
+    with mock.patch("nrk.get", return_value=podcastepisode_metadata) as mocked_get:
+        podcastepisode: PodcastEpisode = PodcastEpisode.from_url(
+            f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}"
+        )
+
+        mocked_get.assert_called_once_with(f'/playback/metadata/podcast/{podcast_series_id}/{podcast_episode_id}')
+
+        assert podcastepisode.id == podcast_episode_id
+        assert podcastepisode.title == "Podcastepisode title: Podcastepisode subtitle"
+        assert (
+            podcastepisode.manifest_url
+            == f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}"
+        )
+
+
+def test_from_url_from_plug_success(podcastepisode_metadata):
+
+    podcast_series_id = "podcast_series_name"
+    podcast_episode_id = "l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+
+    with mock.patch("nrk.get", return_value=podcastepisode_metadata) as mocked_get:
+        podcastepisode = PodcastEpisode.from_url(
+        f"/podcasts/{podcast_series_id}/episodes/{podcast_episode_id}"
+    )
+
+        mocked_get.assert_called_once_with(f'/playback/metadata/podcast/{podcast_series_id}/{podcast_episode_id}')
+
+        assert podcastepisode.id == podcast_episode_id
+        assert podcastepisode.title == "Podcastepisode title: Podcastepisode subtitle"
+        assert (
+            podcastepisode.manifest_url
+            == f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}"
+        )
+
+
+
+def test_from_url_wrong_format():
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        PodcastEpisode.from_url("/ABCDEFG1234567")
+
+
+def test_get_media_url(podcastepisode_manifest):
+    title = "Dummy title"
+    podcast_series_id = "podcast_series_name"
+    podcast_episode_id = "l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+    
+    with mock.patch("nrk.get", return_value=podcastepisode_manifest) as mocked_get:
+        podcastepisode: PodcastEpisode = PodcastEpisode(title, podcast_series_id, podcast_episode_id, [])
+
+        assert (
+            podcastepisode.media_url
+            == "https://example.com/fil/podcast_series_name/019c3d61-c741-7d7f-bb99-84d17abd0a70_0_ID192MP3.mp3"
+        )
+
+        mocked_get.assert_called_once_with(f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}")
+
+
+def test_get_media_url_multiple_calls(podcastepisode_manifest):
+    title = "Dummy title"
+    podcast_series_id = "podcast_series_name"
+    podcast_episode_id = "l_019c3d5f-c860-7fa8-9f53-801dfafeec85"
+    
+    with mock.patch("nrk.get", return_value=podcastepisode_manifest) as mocked_get:
+        podcastepisode: PodcastEpisode = PodcastEpisode(title, podcast_series_id, podcast_episode_id, [])
+
+        assert (
+            podcastepisode.media_url
+            == "https://example.com/fil/podcast_series_name/019c3d61-c741-7d7f-bb99-84d17abd0a70_0_ID192MP3.mp3"
+        )
+        _ = podcastepisode.media_url
+        _ = podcastepisode.media_url
+        _ = podcastepisode.media_url
+        mocked_get.assert_called_once_with(f"/playback/manifest/podcast/{podcast_series_id}/{podcast_episode_id}")

--- a/tests/test_podcastepisodeplug.py
+++ b/tests/test_podcastepisodeplug.py
@@ -1,0 +1,79 @@
+import pytest
+from nrkradio import PodcastEpisodePlug
+
+
+@pytest.fixture
+def podcastepisode_plug_response():
+    return {
+        "type": "podcastEpisode",
+        "_links": {
+            "podcastEpisode": "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf",
+            "podcast": "/podcasts/podcastname",
+            "audioDownload": "https://example.com/fil/podcastname/e491a7cb-af50-411f-b91a-a292021ec8cf_1_ID192MP3.mp3",
+        },
+        "podcastEpisode": {
+            "titles": {
+                "title": "Podcast episode title",
+                "subtitle": "Podcast episode subtitle",
+            },
+            "duration": "PT28M3S",
+            "imageUrl": "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c",
+            "podcast": {"titles": {"title": "Podcast Title"}},
+        },
+    }
+
+
+@pytest.fixture
+def podcastepisode_plug_only_subtitle_response():
+    return {
+        "type": "podcastEpisode",
+        "_links": {
+            "podcastEpisode": "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf",
+            "podcast": "/podcasts/podcastname",
+            "audioDownload": "https://example.com/fil/podcastname/e491a7cb-af50-411f-b91a-a292021ec8cf_1_ID192MP3.mp3",
+        },
+        "podcastEpisode": {
+            "titles": {
+                "subtitle": "Podcast episode subtitle",
+            },
+            "duration": "PT28M3S",
+            "imageUrl": "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c",
+            "podcast": {"titles": {"title": "Podcast Title"}},
+        },
+    }
+
+
+def test_init(podcastepisode_plug_response):
+
+    podcastepisode_plug: PodcastEpisodePlug = PodcastEpisodePlug(
+        podcastepisode_plug_response
+    )
+
+    assert podcastepisode_plug.id == None
+    assert podcastepisode_plug.title == "Podcast Title: Podcast episode title"
+    assert (
+        podcastepisode_plug.manifest_url
+        == "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf"
+    )
+    assert (
+        podcastepisode_plug.thumb
+        == "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c"
+    )
+    assert (
+        podcastepisode_plug.fanart
+        == "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c"
+    )
+
+
+def test_init_only_subtitle(podcastepisode_plug_only_subtitle_response):
+
+    podcastepisode_plug: PodcastEpisodePlug = PodcastEpisodePlug(
+        podcastepisode_plug_only_subtitle_response
+    )
+
+    assert podcastepisode_plug.id == None
+    assert podcastepisode_plug.title == "Podcast Title: Podcast episode subtitle"
+    assert (
+        podcastepisode_plug.manifest_url
+        == "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf"
+    )

--- a/tests/test_podcastplug.py
+++ b/tests/test_podcastplug.py
@@ -1,0 +1,58 @@
+import pytest
+
+from nrkradio import PodcastPlug
+
+
+@pytest.fixture
+def podcast_plug_response():
+    return {
+        "type": "podcast",
+        "_links": {"podcast": "/podcasts/podcastname"},
+        "podcast": {
+            "titles": {
+                "title": "Podcast title",
+                "subtitle": "Podcast subtitle",
+            },
+            "imageUrl": "https://example.com/019c39e9-8c1f-7476-b536-8a300dd9554d",
+            "numberOfEpisodes": 9,
+        },
+    }
+
+@pytest.fixture
+def podcast_plug_only_subtitle_response():
+    return {
+        "type": "podcast",
+        "_links": {"podcast": "/podcasts/podcastname"},
+        "podcast": {
+            "titles": {
+                "subtitle": "Podcast subtitle",
+            },
+            "imageUrl": "https://example.com/019c39e9-8c1f-7476-b536-8a300dd9554d",
+            "numberOfEpisodes": 9,
+        },
+    }
+
+
+def test_init(podcast_plug_response):
+
+    podcast_plug: PodcastPlug = PodcastPlug(podcast_plug_response)
+
+    assert podcast_plug.id == None
+    assert podcast_plug.title == "Podcast title: Podcast subtitle"
+    assert podcast_plug.manifest_url == "/podcasts/podcastname"
+    assert (
+        podcast_plug.thumb
+        == "https://example.com/019c39e9-8c1f-7476-b536-8a300dd9554d"
+    )
+    assert (
+        podcast_plug.fanart
+        == "https://example.com/019c39e9-8c1f-7476-b536-8a300dd9554d"
+    )
+
+def test_init_only_subtitle(podcast_plug_only_subtitle_response):
+
+    podcast_plug: PodcastPlug = PodcastPlug(podcast_plug_only_subtitle_response)
+
+    assert podcast_plug.id == None
+    assert podcast_plug.title == "Podcast subtitle"
+    assert podcast_plug.manifest_url == "/podcasts/podcastname"

--- a/tests/test_season.py
+++ b/tests/test_season.py
@@ -1,0 +1,956 @@
+import copy
+import re
+from re import Match
+from nrk import Base, deep_get_dict, deep_get_list
+from unittest import mock
+import pytest
+
+from nrkradio import PodcastEpisode, Season, StandaloneProgram
+
+
+@pytest.fixture
+def season_podcast_manifest():
+    return {
+        "_links": {
+            "self": {"href": "/radio/catalog/podcast/podcast_name/seasons/202601"},
+            "podcast": {
+                "name": "podcast_name",
+                "href": "/radio/catalog/podcast/podcast_name",
+                "title": "Podcast Title",
+            },
+            "episodes": {
+                "href": "/radio/catalog/podcast/podcast_name/seasons/202601/episodes"
+            },
+            "favourite": {
+                "href": "/radio/userdata/{userId}/favourites/podcast/podcast_name",
+                "templated": True,
+            },
+            "share": {
+                "href": "https://example.com/podkast/podcast_name/sesong/202601"
+            },
+            "primaryAction": {
+                "href": "/radio/userdata/{userId}/primaryaction/podcasts/podcast_name/season/202601",
+                "templated": True,
+            },
+        },
+        "seriesType": "standard",
+        "type": "podcast",
+        "name": "202601",
+        "titles": {"title": "Januar 2026"},
+        "image": [
+            {
+                "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeet57DGpRUnjBBlrknzxEqFA",
+                "width": 300,
+            },
+            {
+                "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeem1fFySW7hn1BlrknzxEqFA",
+                "width": 600,
+            },
+            {
+                "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeeyzzmVDVACd5BlrknzxEqFA",
+                "width": 960,
+            },
+            {
+                "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeeSeavXwRZDOtBlrknzxEqFA",
+                "width": 1280,
+            },
+            {
+                "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeezv3ALjdBQ75BlrknzxEqFA",
+                "width": 1600,
+            },
+            {
+                "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efee-bEFtmssfbJBlrknzxEqFA",
+                "width": 1920,
+            },
+        ],
+        "squareImage": [
+            {
+                "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aJfedFmV-7HunLdQWB0BvZw",
+                "width": 300,
+            },
+            {
+                "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42a6EyM5GivinSnLdQWB0BvZw",
+                "width": 600,
+            },
+            {
+                "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aAQJXLC_6vRunLdQWB0BvZw",
+                "width": 960,
+            },
+            {
+                "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42ajU_KrC4YjqSnLdQWB0BvZw",
+                "width": 1280,
+            },
+            {
+                "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aKqkx59Qw8wCnLdQWB0BvZw",
+                "width": 1600,
+            },
+        ],
+        "backdropImage": [
+            {
+                "url": "https://example.com/019c3d87-c3d8-7c62-9b64-fb6df4d0198220DJl9T5Z7eKh112wPtdNQ",
+                "width": 300,
+            },
+            {
+                "url": "https://example.com/019c3d87-c3d8-7c62-9b64-fb6df4d01982iviNnt34A5KKh112wPtdNQ",
+                "width": 600,
+            },
+            {
+                "url": "https://example.com/019c3d87-c3d8-7c62-9b64-fb6df4d01982epEmdt6eczGKh112wPtdNQ",
+                "width": 960,
+            },
+            {
+                "url": "https://example.com/019c3d87-c3d8-7c62-9b64-fb6df4d01982u-G0Drs76n2Kh112wPtdNQ",
+                "width": 1280,
+            },
+            {
+                "url": "https://example.com/019c3d87-c3d8-7c62-9b64-fb6df4d01982poZaQNr3sLeKh112wPtdNQ",
+                "width": 1600,
+            },
+            {
+                "url": "https://example.com/019c3d87-c3d8-7c62-9b64-fb6df4d01982jejHSZ_udh6Kh112wPtdNQ",
+                "width": 1920,
+            },
+        ],
+        "navigationLinks": [],
+        "hasAvailableEpisodes": True,
+        "episodeCount": 21,
+        "category": {"id": "category-id", "name": "Category Name"},
+        "_embedded": {
+            "episodes": {
+                "_links": {
+                    "self": {
+                        "href": "/radio/catalog/podcast/podcast_name/seasons/202601/episodes?page=1&pageSize=20&sort=desc"
+                    },
+                    "next": {
+                        "href": "/radio/catalog/podcast/podcast_name/seasons/202601/episodes?page=2&pageSize=20&sort=desc"
+                    },
+                    "progresses": [
+                        {
+                            "href": "/radio/userdata/{userId}/progress/podcast/podcast_name?contentIds=H4sIAAAAAAAAAyXSQY4EIAgEwA9NJwiI8JqJoJ7m_-cN2SMVE2jw99Ux511JOCMu9NhEzLuQ1NA12ef3vVJvaRLeHv2MA_6WIqmBD4efz--rlnrfIHDcC8070IBBDZl3RHx-33PC-bqDjyS00tAA94aotP-mJ4M5NshdoHc4GhC7Ie9wvp_fN8n3oVnYVQ9aa6MBsxqq1rb5-X3jkivJhbMzVF7AXQlyG7p-HWEw3whT8DKDcgX2jYBpQ3JFdlN-rlVMYOULnb0QrQJTw5kc9j6_r786Z_VY7ARd-uDnLNRroKXvdtKTy30PwT3q0BcX6b4xpGG8uC87gsmkaw7Kt6CWDznpwrzBLV-tvsKYw3dOHJYNHasQwzdyNsRYRR1hPRGZa4D4CdROIEUm1mgIO1G7k5JvqiMw3xu6l6ABRxrWXuLas9V5SiEgZocab8RTQkiDGW-Vz-8rYlTUN7Ve71DFpqK-qZnNoWodwVI9Rx7I6qSSAvccyNNwJEVHH2tuU8-DI3mgmgMNyNPAmmP0f9O3jcsEJ5ZA6200wKSB622uPxZd-XgLAwAA",
+                            "templated": True,
+                        }
+                    ],
+                },
+                "seriesType": "standard",
+                "_embedded": {
+                    "episodes": [
+                        {
+                            "_links": {
+                                "self": {
+                                    "href": "/radio/catalog/podcast/podcast_name/episodes/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+                                },
+                                "playback": {
+                                    "href": "/playback/metadata/podcast/podcast_name/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+                                },
+                                "series": {
+                                    "name": "podcast_name",
+                                    "href": "/radio/catalog/podcast/podcast_name",
+                                    "title": "Podcast Title",
+                                },
+                                "season": {
+                                    "name": "202601",
+                                    "title": "Januar 2026",
+                                    "href": "/radio/catalog/podcast/podcast_name/seasons/202601",
+                                    "seriesType": "standard",
+                                },
+                                "favourite": {
+                                    "href": "/radio/userdata/{userId}/favourites/podcast/podcast_name",
+                                    "templated": True,
+                                },
+                                "share": {
+                                    "href": "https://example.com/podkast/podcast_name/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+                                },
+                                "progress": {
+                                    "href": "/radio/userdata/{userId}/progress/podcastepisode/podcast_name|l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae",
+                                    "templated": True,
+                                },
+                                "recommendations": {
+                                    "href": "/radio/recommendations/podcast_name?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                                    "templated": True,
+                                },
+                            },
+                            "id": "019c3d89-1808-761e-9218-3bc3dbcfca03",
+                            "episodeId": "l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae",
+                            "titles": {
+                                "title": "Podcast episode title",
+                                "subtitle": "Podcast episode subtitle",
+                            },
+                            "originalTitle": "Podcast Title",
+                            "image": [
+                                {
+                                    "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeet57DGpRUnjBBlrknzxEqFA",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeem1fFySW7hn1BlrknzxEqFA",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeeyzzmVDVACd5BlrknzxEqFA",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeeSeavXwRZDOtBlrknzxEqFA",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeezv3ALjdBQ75BlrknzxEqFA",
+                                    "width": 1600,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efee-bEFtmssfbJBlrknzxEqFA",
+                                    "width": 1920,
+                                },
+                            ],
+                            "squareImage": [
+                                {
+                                    "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aJfedFmV-7HunLdQWB0BvZw",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42a6EyM5GivinSnLdQWB0BvZw",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aAQJXLC_6vRunLdQWB0BvZw",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42ajU_KrC4YjqSnLdQWB0BvZw",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aKqkx59Qw8wCnLdQWB0BvZw",
+                                    "width": 1600,
+                                },
+                            ],
+                            "duration": "PT15M3S",
+                            "date": "2026-01-30T08:00:00+01:00",
+                            "durationInSeconds": 903,
+                            "usageRights": {
+                                "from": {
+                                    "date": "2026-01-30T08:00:00+01:00",
+                                    "displayValue": "30. januar 2026 kl. 08:00",
+                                },
+                                "to": {
+                                    "date": "9999-12-22T00:59:59+01:00",
+                                    "displayValue": "Alltid tilgjengelig",
+                                },
+                                "geoBlock": {
+                                    "isGeoBlocked": False,
+                                    "displayValue": "Verden",
+                                },
+                            },
+                            "availability": {"status": "available", "hasLabel": False},
+                            "badges": [],
+                            "category": {"id": "category-id", "name": "Category Name"},
+                        },
+                    ]
+                },
+            }
+        },
+    }
+
+
+@pytest.fixture
+def season_podcast_episodes_page_1():
+    return {
+        "_links": {
+            "self": {
+                "href": "/radio/catalog/podcast/politisk_kvarter/seasons/202601/episodes?page=1&pageSize=50&sort=desc"
+            },
+            "progresses": [
+                {
+                    "href": "/radio/userdata/{userId}/progress/podcast/politisk_kvarter?contentIds=H4sIAAAAAAAAAyXSQY4EIAgEwA9NJwqI8JqJgJ7m_-cN2aMVE2jb31fmWnfHQE2_kNIFX3cjRkOfh35-38v5tsTAO7OvkcPeFsRooCK3-vy-oiH3zQHyeyFxJxowR0PEne6f37fKja4ZqDggGYoGmDV4hv4PrXAiPxhmDLnT0AA_DXGn0f38vjHs1FiJk_kguQ8asLIhcx9dn9_X7zAZfGFkBOHnMJMBvg19fh1hEl13FdBWhVA6znWHSkNQevRQeiaZNEBCF7L6QSQTNBpqkev7_L72smr3WmQDsuXBqjbyNYwt73bSim12JuOWGOT5RZgdTG6Yz--LjqC8xlXDiLchGg-xxoVag2m83N3CXNNOLBTxgcyd8GkHsRp87hwdYT9mXnti0GOIliOYF_ZscC3P00mHnZHFUDsHcjajAcUN-2w26d2yngxnDCKDKB34kwHnBlU6wp_fl1lHju5U-3mnCM7I0Z2q6poi2hE0xGJGgXcn5WCYxURUQ3GwzC5rHRWLQnEURGKiAVENJDFn_zd5RymVUb4Zku-gAcoNlO9QdllcdHT1UEvIqQWno1jVoKcWrz-K8TJfMgMAAA",
+                    "templated": True,
+                }
+            ],
+        },
+        "seriesType": "standard",
+        "_embedded": {
+            "episodes": [
+                {
+                    "_links": {
+                        "self": {
+                            "href": "/radio/catalog/podcast/podcast_name/episodes/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+                        },
+                        "playback": {
+                            "href": "/playback/metadata/podcast/podcast_name/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+                        },
+                        "series": {
+                            "name": "podcast_name",
+                            "href": "/radio/catalog/podcast/podcast_name",
+                            "title": "Podcast Title",
+                        },
+                        "season": {
+                            "name": "202601",
+                            "title": "Januar 2026",
+                            "href": "/radio/catalog/podcast/podcast_name/seasons/202601",
+                            "seriesType": "standard",
+                        },
+                        "favourite": {
+                            "href": "/radio/userdata/{userId}/favourites/podcast/podcast_name",
+                            "templated": True,
+                        },
+                        "share": {
+                            "href": "https://example.com/podkast/podcast_name/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+                        },
+                        "progress": {
+                            "href": "/radio/userdata/{userId}/progress/podcastepisode/podcast_name|l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae",
+                            "templated": True,
+                        },
+                        "recommendations": {
+                            "href": "/radio/recommendations/podcast_name?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                            "templated": True,
+                        },
+                    },
+                    "id": "019c3d89-1808-761e-9218-3bc3dbcfca03",
+                    "episodeId": "l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae",
+                    "titles": {
+                        "title": "Podcast episode title",
+                        "subtitle": "Podcast episode subtitle",
+                    },
+                    "originalTitle": "Podcast Title",
+                    "image": [
+                        {
+                            "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeet57DGpRUnjBBlrknzxEqFA",
+                            "width": 300,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeem1fFySW7hn1BlrknzxEqFA",
+                            "width": 600,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeeyzzmVDVACd5BlrknzxEqFA",
+                            "width": 960,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeeSeavXwRZDOtBlrknzxEqFA",
+                            "width": 1280,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeezv3ALjdBQ75BlrknzxEqFA",
+                            "width": 1600,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efee-bEFtmssfbJBlrknzxEqFA",
+                            "width": 1920,
+                        },
+                    ],
+                    "squareImage": [
+                        {
+                            "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aJfedFmV-7HunLdQWB0BvZw",
+                            "width": 300,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42a6EyM5GivinSnLdQWB0BvZw",
+                            "width": 600,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aAQJXLC_6vRunLdQWB0BvZw",
+                            "width": 960,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42ajU_KrC4YjqSnLdQWB0BvZw",
+                            "width": 1280,
+                        },
+                        {
+                            "url": "https://example.com/019c3d87-7f4d-7c5c-9dc0-43bbe95fe42aKqkx59Qw8wCnLdQWB0BvZw",
+                            "width": 1600,
+                        },
+                    ],
+                    "duration": "PT15M3S",
+                    "date": "2026-01-30T08:00:00+01:00",
+                    "durationInSeconds": 903,
+                    "usageRights": {
+                        "from": {
+                            "date": "2026-01-30T08:00:00+01:00",
+                            "displayValue": "30. januar 2026 kl. 08:00",
+                        },
+                        "to": {
+                            "date": "9999-12-22T00:59:59+01:00",
+                            "displayValue": "Alltid tilgjengelig",
+                        },
+                        "geoBlock": {
+                            "isGeoBlocked": False,
+                            "displayValue": "Verden",
+                        },
+                    },
+                    "availability": {"status": "available", "hasLabel": False},
+                    "badges": [],
+                    "category": {"id": "category-id", "name": "Category Name"},
+                }
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def season_series_manifest():
+    return {
+        "_links": {
+            "self": {"href": "/radio/catalog/series/series-name/seasons/202505"},
+            "series": {
+                "name": "series-name",
+                "href": "/radio/catalog/series/series-name",
+                "title": "Series Title",
+            },
+            "episodes": {
+                "href": "/radio/catalog/series/series-name/seasons/202505/episodes"
+            },
+            "primaryAction": {
+                "href": "/radio/userdata/{userId}/primaryaction/series/series-name/season/202505",
+                "templated": True,
+            },
+        },
+        "seriesType": "standard",
+        "type": "series",
+        "titles": {"title": "Mai 2025"},
+        "image": [
+            {
+                "url": "https://example.com/019c3dbf-21e5-7889-a986-2eed285434646A840Arjkr-_75kmSkSOeg",
+                "width": 300,
+            },
+            {
+                "url": "https://example.com/019c3dbf-21e5-7889-a986-2eed28543464f6TFdjHDsoS_75kmSkSOeg",
+                "width": 600,
+            },
+            {
+                "url": "https://example.com/019c3dbf-21e5-7889-a986-2eed28543464z6_B4R7EMI-_75kmSkSOeg",
+                "width": 960,
+            },
+            {
+                "url": "https://example.com/019c3dbf-21e5-7889-a986-2eed28543464pPd-tw4pzam_75kmSkSOeg",
+                "width": 1280,
+            },
+            {
+                "url": "https://example.com/019c3dbf-21e5-7889-a986-2eed28543464kq2A0WiDvdq_75kmSkSOeg",
+                "width": 1600,
+            },
+            {
+                "url": "https://example.com/019c3dbf-21e5-7889-a986-2eed285434649tA_ScAmw6e_75kmSkSOeg",
+                "width": 1920,
+            },
+        ],
+        "hasAvailableEpisodes": True,
+        "episodeCount": 6,
+        "_embedded": {
+            "episodes": {
+                "_links": {
+                    "self": {
+                        "href": "/radio/catalog/series/series-name/seasons/202505/episodes?page=1&pageSize=20&sort=desc"
+                    },
+                    "progresses": [
+                        {
+                            "href": "/radio/userdata/{userId}/progress/series/series-name?contentIds=H4sIAAAAAAAAA_P19g01MDMyMDAzMtXxhXFMkTkmyBxjZI4RMsfQyBQAUnyJvU0AAAA",
+                            "templated": True,
+                        }
+                    ],
+                },
+                "seriesType": "standard",
+                "_embedded": {
+                    "episodes": [
+                        {
+                            "_links": {
+                                "self": {"href": "/radio/catalog/programs/YXCVB987654"},
+                                "playback": {
+                                    "href": "/playback/metadata/program/YXCVB987654"
+                                },
+                                "series": {
+                                    "name": "series-name",
+                                    "href": "/radio/catalog/series/series-name",
+                                    "title": "Series Title",
+                                },
+                                "season": {
+                                    "name": "202505",
+                                    "title": "Mai 2025",
+                                    "href": "/radio/catalog/series/series-name/seasons/202505",
+                                    "seriesType": "standard",
+                                },
+                                "favourite": {
+                                    "href": "/radio/userdata/{userId}/favourites/series/series-name",
+                                    "templated": True,
+                                },
+                                "share": {
+                                    "href": "https://example.com/serie/series-name/YXCVB987654"
+                                },
+                                "progress": {
+                                    "href": "/radio/userdata/{userId}/progress/programs/YXCVB987654",
+                                    "templated": True,
+                                },
+                                "recommendations": {
+                                    "href": "/radio/recommendations/YXCVB987654?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                                    "templated": True,
+                                },
+                            },
+                            "id": "8ff58caef93c6e760cf18406e41c8f9a",
+                            "episodeId": "YXCVB987654",
+                            "titles": {
+                                "title": "Program title",
+                                "subtitle": "Program subtitle",
+                            },
+                            "image": [
+                                {
+                                    "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddo3FUALEaZ6FUr_ro5v_InA",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddUGWalBA6tl5Ur_ro5v_InA",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddnp805RQb6G5Ur_ro5v_InA",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddgRNnl72vGO9Ur_ro5v_InA",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddhM3DuGDLR_hUr_ro5v_InA",
+                                    "width": 1600,
+                                },
+                                {
+                                    "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddm2IjJ5GibV1Ur_ro5v_InA",
+                                    "width": 1920,
+                                },
+                            ],
+                            "duration": "PT57M",
+                            "date": "2025-05-01T15:03:00+02:00",
+                            "durationInSeconds": 3420,
+                            "usageRights": {
+                                "from": {
+                                    "date": "2025-05-01T15:03:00+02:00",
+                                    "displayValue": "1. mai 2025 kl. 15:03",
+                                },
+                                "to": {
+                                    "date": "2100-01-01T23:03:00+01:00",
+                                    "displayValue": "Alltid tilgjengelig",
+                                },
+                                "geoBlock": {
+                                    "isGeoBlocked": False,
+                                    "displayValue": "Verden",
+                                },
+                            },
+                            "productionYear": 2025,
+                            "availability": {"status": "available", "hasLabel": False},
+                            "contributors": [
+                                {"name": "Sara Amundsen", "role": "Programleder"},
+                                {"name": "Viljar Iqbal", "role": "Programleder"},
+                                {"name": "Isak Strand", "role": "Medvirkende"},
+                                {"name": "Levi Hammer", "role": "Lydtekniker"},
+                                {
+                                    "name": "Esther Evensen",
+                                    "role": "Prosjektleder",
+                                },
+                            ],
+                            "badges": [],
+                        }
+                    ]
+                },
+            }
+        },
+    }
+
+
+@pytest.fixture
+def season_series_episodes_page_1():
+    return {
+        "_links": {
+            "self": {
+                "href": "/radio/catalog/series/series-name/seasons/202505/episodes?page=1&pageSize=50&sort=desc"
+            },
+            "progresses": [
+                {
+                    "href": "/radio/userdata/{userId}/progress/series/series-name?contentIds=H4sIAAAAAAAAA_P19g01MDMyMDAzMtXxhXFMkTkmyBxjZI4RMsfQyBQAUnyJvU0AAAA",
+                    "templated": True,
+                }
+            ],
+        },
+        "seriesType": "standard",
+        "_embedded": {
+            "episodes": [
+                {
+                    "_links": {
+                        "self": {"href": "/radio/catalog/programs/YXCVB987654"},
+                        "playback": {"href": "/playback/metadata/program/YXCVB987654"},
+                        "series": {
+                            "name": "series-name",
+                            "href": "/radio/catalog/series/series-name",
+                            "title": "Series Title",
+                        },
+                        "season": {
+                            "name": "202505",
+                            "title": "Mai 2025",
+                            "href": "/radio/catalog/series/series-name/seasons/202505",
+                            "seriesType": "standard",
+                        },
+                        "favourite": {
+                            "href": "/radio/userdata/{userId}/favourites/series/series-name",
+                            "templated": True,
+                        },
+                        "share": {
+                            "href": "https://example.com/serie/series-name/YXCVB987654"
+                        },
+                        "progress": {
+                            "href": "/radio/userdata/{userId}/progress/programs/YXCVB987654",
+                            "templated": True,
+                        },
+                        "recommendations": {
+                            "href": "/radio/recommendations/YXCVB987654?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                            "templated": True,
+                        },
+                    },
+                    "id": "8ff58caef93c6e760cf18406e41c8f9a",
+                    "episodeId": "YXCVB987654",
+                    "titles": {
+                        "title": "Program title",
+                        "subtitle": "Program subtitle",
+                    },
+                    "image": [
+                        {
+                            "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddo3FUALEaZ6FUr_ro5v_InA",
+                            "width": 300,
+                        },
+                        {
+                            "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddUGWalBA6tl5Ur_ro5v_InA",
+                            "width": 600,
+                        },
+                        {
+                            "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddnp805RQb6G5Ur_ro5v_InA",
+                            "width": 960,
+                        },
+                        {
+                            "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddgRNnl72vGO9Ur_ro5v_InA",
+                            "width": 1280,
+                        },
+                        {
+                            "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddhM3DuGDLR_hUr_ro5v_InA",
+                            "width": 1600,
+                        },
+                        {
+                            "url": "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddm2IjJ5GibV1Ur_ro5v_InA",
+                            "width": 1920,
+                        },
+                    ],
+                    "duration": "PT57M",
+                    "date": "2025-05-01T15:03:00+02:00",
+                    "durationInSeconds": 3420,
+                    "usageRights": {
+                        "from": {
+                            "date": "2025-05-01T15:03:00+02:00",
+                            "displayValue": "1. mai 2025 kl. 15:03",
+                        },
+                        "to": {
+                            "date": "2100-01-01T23:03:00+01:00",
+                            "displayValue": "Alltid tilgjengelig",
+                        },
+                        "geoBlock": {
+                            "isGeoBlocked": False,
+                            "displayValue": "Verden",
+                        },
+                    },
+                    "productionYear": 2025,
+                    "availability": {"status": "available", "hasLabel": False},
+                    "contributors": [
+                        {"name": "Sara Amundsen", "role": "Programleder"},
+                        {"name": "Viljar Iqbal", "role": "Programleder"},
+                        {"name": "Isak Strand", "role": "Medvirkende"},
+                        {"name": "Levi Hammer", "role": "Lydtekniker"},
+                        {
+                            "name": "Esther Evensen",
+                            "role": "Prosjektleder",
+                        },
+                    ],
+                    "badges": [],
+                }
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def mock_nrk_get(
+    season_podcast_manifest,
+    season_podcast_episodes_page_1,
+    season_series_manifest,
+    season_series_episodes_page_1,
+):
+    def _fake_nrk_get(*, path, params=None):
+        podcast_manifest_url = "/radio/catalog/podcast/podcast_name/seasons/202601"
+        series_manifest_url = "/radio/catalog/series/series-name/seasons/202505"
+
+        page_size = 0
+        page = 0
+
+        if path == podcast_manifest_url and params is None:
+            return season_podcast_manifest
+        elif path == series_manifest_url and params is None:
+            return season_series_manifest
+        elif params:
+            search_object: Match[str] | None = re.search(r"page=([0-9]+)&", params)
+            if search_object:
+                page: int = int(search_object.group(1))
+            search_object: Match[str] | None = re.search(r"pageSize=([0-9]+)&", params)
+            if search_object:
+                page_size: int = int(search_object.group(1))
+
+            episodes_on_page: int = _episodes_on_page(page, page_size)
+
+            if path == f"{podcast_manifest_url}/episodes":
+                page_copy = copy.deepcopy(season_podcast_episodes_page_1)
+                episode_copy = copy.deepcopy(
+                    season_podcast_episodes_page_1["_embedded"]["episodes"][0]
+                )
+            elif path == f"{series_manifest_url}/episodes":
+                page_copy = copy.deepcopy(season_series_episodes_page_1)
+                episode_copy = copy.deepcopy(
+                    season_series_episodes_page_1["_embedded"]["episodes"][0]
+                )
+            else:
+                raise AssertionError(f"Unexpected call: path={path}, params={params}")
+
+            page_copy["_embedded"]["episodes"] = [
+                copy.deepcopy(episode_copy) for _ in range(episodes_on_page)
+            ]
+            return page_copy
+
+        raise AssertionError(f"Unexpected call: path={path}, params={params}")
+
+    def _episodes_on_page(page: int, page_size: int) -> int:
+        total_episodes = 80
+        full_pages = total_episodes // page_size
+        remainder = total_episodes % page_size
+        if page <= full_pages:
+            return page_size
+        elif page == full_pages + 1:
+            return remainder
+        else:
+            return 0
+
+    with mock.patch("nrk.get", side_effect=_fake_nrk_get) as mocked:
+        yield mocked
+
+
+def test_init(season_podcast_manifest):
+    title = "Dummy title"
+    manifest_url = "/playback/id"
+    images = deep_get_list(season_podcast_manifest, "image")
+    season: Season = Season(title, manifest_url, images)
+
+    assert season.title == title
+    assert season.manifest_url == manifest_url
+    assert (
+        season.thumb
+        == "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeet57DGpRUnjBBlrknzxEqFA"
+    )
+    assert (
+        season.fanart
+        == "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efee-bEFtmssfbJBlrknzxEqFA"
+    )
+
+
+def test_from_url_from_season_success(season_podcast_manifest):
+
+    podcast_series_id = "podcast_name"
+    podcast_season_id = "202601"
+    manifest_url = (
+        f"/radio/catalog/podcast/{podcast_series_id}/seasons/{podcast_season_id}"
+    )
+
+    with mock.patch("nrk.get", return_value=season_podcast_manifest) as mocked_get:
+        season: Season = Season.from_url(manifest_url)
+
+        mocked_get.assert_called_once_with(manifest_url)
+
+        assert season.title == "Januar 2026"
+        assert season.manifest_url == manifest_url
+        assert (
+            season.thumb
+            == "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeet57DGpRUnjBBlrknzxEqFA"
+        )
+        assert (
+            season.fanart
+            == "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efee-bEFtmssfbJBlrknzxEqFA"
+        )
+
+
+def test_from_url_from_plug_success(season_series_manifest):
+
+    podcast_series_id = "series-name"
+    podcast_season_id = "202505"
+    manifest_url = (
+        f"/radio/catalog/series/{podcast_series_id}/seasons/{podcast_season_id}"
+    )
+
+    with mock.patch("nrk.get", return_value=season_series_manifest) as mocked_get:
+        season: Season = Season.from_url(manifest_url)
+
+        mocked_get.assert_called_once_with(manifest_url)
+
+        assert season.title == "Mai 2025"
+        assert season.manifest_url == manifest_url
+        assert (
+            season.thumb
+            == "https://example.com/019c3dbf-21e5-7889-a986-2eed285434646A840Arjkr-_75kmSkSOeg"
+        )
+        assert (
+            season.fanart
+            == "https://example.com/019c3dbf-21e5-7889-a986-2eed285434649tA_ScAmw6e_75kmSkSOeg"
+        )
+
+
+def test_from_url_wrong_format():
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        _ = Season.from_url("/radio/only-two-parts")
+
+
+def test_get_children_of_podcast(
+    mock_nrk_get, season_podcast_manifest, season_podcast_episodes_page_1
+):
+    podcast_series_id = "podcast_name"
+    podcast_season_id = "202601"
+    manifest_url = (
+        f"/radio/catalog/podcast/{podcast_series_id}/seasons/{podcast_season_id}"
+    )
+    total_episodes = 80
+    season: Season = Season("Dummy title", manifest_url, [])
+
+    children: list[Base] = season.children
+
+    mock_nrk_get.assert_has_calls(
+        calls=[
+            mock.call(path=f"{manifest_url}"),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=1&pageSize=50&sort=desc",
+            ),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=2&pageSize=50&sort=desc",
+            ),
+        ]
+    )
+    assert len(children) == total_episodes
+    assert [isinstance(child, PodcastEpisode) for child in children] == [
+        True for _ in range(total_episodes)
+    ]
+    assert children[0].title == "Podcast episode title"
+    assert (
+        children[0].manifest_url
+        == "/playback/manifest/podcast/podcast_name/l_019c3dbd-bb8b-73b7-80c7-31536d3d90ae"
+    )
+    assert (
+        children[0].thumb
+        == "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efeet57DGpRUnjBBlrknzxEqFA"
+    )
+    assert (
+        children[0].fanart
+        == "https://example.com/019c3d87-3ca5-7fe2-a9fe-5fcf8eb2efee-bEFtmssfbJBlrknzxEqFA"
+    )
+
+
+def test_get_children_of_podcast_multiple_calls(
+    mock_nrk_get, season_podcast_manifest, season_podcast_episodes_page_1
+):
+    podcast_series_id = "podcast_name"
+    podcast_season_id = "202601"
+    manifest_url = (
+        f"/radio/catalog/podcast/{podcast_series_id}/seasons/{podcast_season_id}"
+    )
+    total_episodes = 80
+    season: Season = Season("Dummy title", manifest_url, [])
+
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+
+    mock_nrk_get.assert_has_calls(
+        calls=[
+            mock.call(path=f"{manifest_url}"),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=1&pageSize=50&sort=desc",
+            ),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=2&pageSize=50&sort=desc",
+            ),
+        ]
+    )
+    assert len(children) == total_episodes
+
+
+def test_get_children_of_series(mock_nrk_get):
+    podcast_series_id = "series-name"
+    podcast_season_id = "202505"
+    manifest_url = (
+        f"/radio/catalog/series/{podcast_series_id}/seasons/{podcast_season_id}"
+    )
+    total_episodes = 80
+    season: Season = Season("Dummy title", manifest_url, [])
+
+    children: list[Base] = season.children
+
+    mock_nrk_get.assert_has_calls(
+        calls=[
+            mock.call(path=f"{manifest_url}"),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=1&pageSize=50&sort=desc",
+            ),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=2&pageSize=50&sort=desc",
+            ),
+        ]
+    )
+
+    assert len(children) == total_episodes
+    assert [isinstance(child, StandaloneProgram) for child in children] == [
+        True for _ in range(total_episodes)
+    ]
+    assert children[0].title == "Program title"
+    assert children[0].manifest_url == "/playback/manifest/program/YXCVB987654"
+    assert (
+        children[0].thumb
+        == "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddo3FUALEaZ6FUr_ro5v_InA"
+    )
+    assert (
+        children[0].fanart
+        == "https://example.com/019c3dc1-2130-79e2-a352-fd9c18a518ddm2IjJ5GibV1Ur_ro5v_InA"
+    )
+
+
+def test_get_children_of_series_multiple_calls(mock_nrk_get):
+    podcast_series_id = "series-name"
+    podcast_season_id = "202505"
+    manifest_url = (
+        f"/radio/catalog/series/{podcast_series_id}/seasons/{podcast_season_id}"
+    )
+    total_episodes = 80
+    season: Season = Season("Dummy title", manifest_url, [])
+
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+    children: list[Base] = season.children
+
+    mock_nrk_get.assert_has_calls(
+        calls=[
+            mock.call(path=f"{manifest_url}"),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params=f"&page=1&pageSize=50&sort=desc",
+            ),
+            mock.call(
+                path=f"{manifest_url}/episodes",
+                params="&page=2&pageSize=50&sort=desc",
+            ),
+        ]
+    )
+
+    assert len(children) == total_episodes

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,0 +1,352 @@
+from nrk import Base
+from nrkradio import Section
+import pytest
+from unittest import mock
+
+
+@pytest.fixture
+def full_page_response():
+    """A minimal response containing an ``included`` block."""
+    return {
+        "title": "Placeholder Page Title",
+        "sections": [
+            {
+                "included": {
+                    "title": "Section Title",
+                    "plugs": [
+                        {
+                            "type": "podcastEpisode",
+                            "_links": {
+                                "podcastEpisode": "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf",
+                                "podcast": "/podcasts/podcastname",
+                                "audioDownload": "https://example.com/fil/podcastname/e491a7cb-af50-411f-b91a-a292021ec8cf_1_ID192MP3.mp3",
+                            },
+                            "podcastEpisode": {
+                                "titles": {
+                                    "title": "Podcast episode title",
+                                    "subtitle": "Podcast episode subtitle",
+                                },
+                                "duration": "PT28M3S",
+                                "imageUrl": "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c",
+                                "podcast": {"titles": {"title": "Podcast Title"}},
+                            },
+                        },
+                        {
+                            "type": "channel",
+                            "_links": {"channel": "/mediaelement/channelname"},
+                            "channel": {
+                                "titles": {"title": "Channel title"},
+                                "image": {
+                                    "id": "019c39da-d036-70f5-9c30-9c7179f233ff",
+                                    "webImages": [
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff7H9WHy0d_QEvZ41HevX4tQ",
+                                            "width": 300,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffnptQAWmTl0QvZ41HevX4tQ",
+                                            "width": 600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffNE58lEqQAswvZ41HevX4tQ",
+                                            "width": 960,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffktYCmVGM_QUvZ41HevX4tQ",
+                                            "width": 1280,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ffBdvbxUqgPHYvZ41HevX4tQ",
+                                            "width": 1600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39da-d036-70f5-9c30-9c7179f233ff1ean57gyYhQvZ41HevX4tQ",
+                                            "width": 1920,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        {
+                            "type": "standaloneProgram",
+                            "_links": {
+                                "program": "/programs/ABCDE12345678",
+                                "mediaelement": "/mediaelement/ABCDE12345678",
+                            },
+                            "program": {
+                                "titles": {
+                                    "title": "Program Title",
+                                    "subtitle": "Program subtitle",
+                                },
+                                "image": {
+                                    "id": "019c39dd-ab7a-7a8f-8e17-4ddabd55f683",
+                                    "webImages": [
+                                        {
+                                            "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683_yDO3z4Ntptdhmb3_Ub0iQ",
+                                            "width": 300,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683rLa_uVTOE_pdhmb3_Ub0iQ",
+                                            "width": 600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683GlIIpPHIX9Rdhmb3_Ub0iQ",
+                                            "width": 960,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683gl23UWjOJA5dhmb3_Ub0iQ",
+                                            "width": 1280,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683Illh5pIabwNdhmb3_Ub0iQ",
+                                            "width": 1600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f6831ilEZT80k3tdhmb3_Ub0iQ",
+                                            "width": 1920,
+                                        },
+                                    ],
+                                },
+                                "duration": "PT0S",
+                            },
+                        },
+                        {
+                            "type": "podcast",
+                            "_links": {"podcast": "/podcasts/podcastname"},
+                            "podcast": {
+                                "titles": {
+                                    "title": "Podcast title",
+                                    "subtitle": "Podcast subtitle",
+                                },
+                                "imageUrl": "https://example.com/019c39e9-8c1f-7476-b536-8a300dd9554d",
+                                "numberOfEpisodes": 9,
+                            },
+                        },
+                        {
+                            "type": "series",
+                            "_links": {"series": "/series/seriesname"},
+                            "series": {
+                                "titles": {
+                                    "title": "Series title",
+                                    "subtitle": "Series subtitle",
+                                },
+                                "image": {
+                                    "id": "019c39ea-f0b7-7463-9aa3-9b63639053ec",
+                                    "webImages": [
+                                        {
+                                            "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecPMwQEKDdQrtaBbEZIzo36w",
+                                            "width": 300,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecQpyYH7B0NsZaBbEZIzo36w",
+                                            "width": 600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053eccDtEveYObMJaBbEZIzo36w",
+                                            "width": 960,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ec1EaKbUK3LLNaBbEZIzo36w",
+                                            "width": 1280,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053eczZtNkmL5zmZaBbEZIzo36w",
+                                            "width": 1600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecmkrwoQ1iInxaBbEZIzo36w",
+                                            "width": 1920,
+                                        },
+                                    ],
+                                },
+                                "numberOfEpisodes": 1,
+                            },
+                        },
+                        {
+                            "type": "episode",
+                            "_links": {
+                                "episode": "/programs/ABCDEFG12345678",
+                                "mediaelement": "/mediaelement/ABCDEFG12345678",
+                                "series": "/series/seriesname",
+                                "season": "/series/seriesname/seasons/0/episodes",
+                            },
+                            "episode": {
+                                "titles": {
+                                    "title": "Episode title",
+                                    "subtitle": "Episode subtitle",
+                                },
+                                "image": {
+                                    "id": "019c39ec-1deb-7ec7-989d-e11ad4024165",
+                                    "webImages": [
+                                        {
+                                            "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165fmIQECFtGh-Z6FOsEAclhA",
+                                            "width": 300,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165xFzIdgDHG7yZ6FOsEAclhA",
+                                            "width": 600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165g7wscWA5W0SZ6FOsEAclhA",
+                                            "width": 960,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165g-lYjMeaUq6Z6FOsEAclhA",
+                                            "width": 1280,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165JcUtlKdzziiZ6FOsEAclhA",
+                                            "width": 1600,
+                                        },
+                                        {
+                                            "uri": "https://example.com/019c39ec-1deb-7ec7-989d-e11ad4024165Wlj7LVBuuqOZ6FOsEAclhA",
+                                            "width": 1920,
+                                        },
+                                    ],
+                                },
+                                "duration": "PT57M",
+                                "series": {"titles": {"title": "Series title"}},
+                            },
+                        },
+                    ],
+                }
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def section_response():
+    """A minimal response containing an ``included`` block."""
+    return {
+        "included": {
+            "title": "Section Title",
+            "plugs": [
+                {
+                    "type": "podcastEpisode",
+                    "_links": {
+                        "podcastEpisode": "/podcasts/podcastname/episodes/l_e491a7cb-af50-411f-b91a-a292021ec8cf",
+                        "podcast": "/podcasts/podcastname",
+                        "audioDownload": "https://example.com/fil/podcastname/e491a7cb-af50-411f-b91a-a292021ec8cf_1_ID192MP3.mp3",
+                    },
+                    "podcastEpisode": {
+                        "titles": {
+                            "title": "Podcast episode title",
+                            "subtitle": "Podcast episode subtitle",
+                        },
+                        "duration": "PT28M3S",
+                        "imageUrl": "https://example.com/019c39d5-f487-7d26-8550-f924592f8d9c",
+                        "podcast": {"titles": {"title": "Podcast Title"}},
+                    },
+                }
+            ],
+        }
+    }
+
+
+def test_init_with_full_page_response(full_page_response):
+    """
+    Verify that a Section created from a response that contains an
+    ``included`` block extracts the title and creates plug objects.
+    """
+    sec = Section(page_id="drama", section_id="0", response=full_page_response)
+
+    # Title should come from the ``included`` dict.
+    assert sec.title == "Section Title"
+
+    # Path must reflect the page and section identifiers.
+    assert sec.manifest_url == "/pages/drama/0"
+
+    assert sec.thumb == None
+    assert sec.fanart == None
+
+    # Six plugs should have been instantiated via ``plug_factory``.
+    assert len(sec.children) == 6
+    assert all(isinstance(p, Base) for p in sec.children)
+    # The titles of the children should match the titles in the response
+    assert [p.title for p in sec.children] == [
+        "Podcast Title: Podcast episode title",
+        "Channel title",
+        "Program Title: Program subtitle",
+        "Podcast title: Podcast subtitle",
+        "Series title: Series subtitle",
+        "Series title: Episode title: Episode subtitle"
+    ]
+
+
+def test_init_with_section_response(section_response):
+    """
+    Verify that a Section created from a response that contains an
+    ``included`` block extracts the title and creates plug objects.
+    """
+    sec = Section(page_id="drama", section_id="0", response=section_response)
+
+    # Title should come from the ``included`` dict.
+    assert sec.title == "Section Title"
+
+    # Path must reflect the page and section identifiers.
+    assert sec.manifest_url == "/pages/drama/0"
+
+    assert sec.thumb == None
+    assert sec.fanart == None
+
+    # One plug should have been instantiated via ``plug_factory``.
+    assert len(sec.children) == 1
+    assert all(isinstance(p, Base) for p in sec.children)
+    # The titles of the children should match the titles in the response
+    assert [p.title for p in sec.children] == [
+        "Podcast Title: Podcast episode title"
+    ]
+
+
+def test_init_without_any_block():
+    """
+    If the response contains neither ``included`` nor ``placeholder``,
+    the title should be ``None`` and no children should be added.
+    """
+    empty_resp = {"sections": [{"foo": "bar"}]}
+    sec = Section(page_id="99", section_id="0", response=empty_resp)
+
+    assert sec.title == "Ingen tittel"
+    assert sec.manifest_url == "/pages/99/0"
+    assert sec.children == []
+
+
+def test_from_url_success(full_page_response):
+    """
+    ``from_url`` should split the URL, request the correct endpoint 
+    and return a fully initialised Section.
+    """
+    
+
+
+
+    with mock.patch("nrk.get", return_value=full_page_response) as mocked_get:
+        sec = Section.from_url("radio/pages/pagename/0")
+
+        # ---- Assertions about the call ------------------------------
+        mocked_get.assert_called_once_with("/radio/pages/pagename")
+
+        # ---- Assertions about the created Section -------------------
+        assert sec.id == "0"
+        assert sec.manifest_url == "/pages/pagename/0"
+        # Title comes from the `included` block of the fake response.
+        assert sec.title == "Section Title"
+        # Six plugs should have been created via `plug_factory`.
+        assert len(sec.children) == 6
+        assert [p.title for p in sec.children] == [
+        "Podcast Title: Podcast episode title",
+        "Channel title",
+        "Program Title: Program subtitle",
+        "Podcast title: Podcast subtitle",
+        "Series title: Series subtitle",
+        "Series title: Episode title: Episode subtitle"
+    ]
+
+
+def test_from_url_invalid_format():
+    """
+    An incorrectly formatted URL should raise ``ValueError``.
+    """
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        _ = Section.from_url("https://example.com/radio/only-two-parts")

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1,0 +1,276 @@
+import pytest
+from unittest import mock
+from nrkradio import Season, Series
+
+
+@pytest.fixture
+def series_manifest():
+    return {
+        "_links": {
+            "self": {"href": "/radio/catalog/series/series-name"},
+            "seasons": [
+                {
+                    "name": "202505",
+                    "href": "/radio/catalog/series/series-name/seasons/202505",
+                    "title": "Mai 2025",
+                }
+            ],
+            "userData": {
+                "href": "/radio/userdata/series/series-name/{userId}",
+                "templated": True,
+            },
+            "episodes": {"href": "/radio/catalog/series/series-name/episodes"},
+            "highlightedEpisode": {
+                "href": "/radio/userdata/{userId}/progress/series/series-name/highlightedProgram",
+                "templated": True,
+            },
+            "primaryAction": {
+                "href": "/radio/userdata/{userId}/primaryaction/series/series-name",
+                "templated": True,
+            },
+            "favourite": {
+                "href": "/radio/userdata/{userId}/favourites/series/series-name",
+                "templated": True,
+            },
+            "share": {"href": "https://example.com/serie/series-name"},
+        },
+        "seriesType": "standard",
+        "type": "series",
+        "seasonDisplayType": "month",
+        "navigationLinks": [],
+        "series": {
+            "id": "series-name",
+            "highlightedEpisode": "019c4988-393c-724a-870a-42c0bd2450ad",
+            "titles": {
+                "title": "Series Title",
+                "subtitle": "Series Subtitle",
+            },
+            "category": {"id": "category-id", "name": "Category Name"},
+            "image": [
+                {
+                    "url": "https://example.com/019c4988-b05a-7aec-91ad-71a8263312a96A840Arjkr-_75kmSkSOeg",
+                    "width": 300,
+                },
+                {
+                    "url": "https://example.com/019c4988-b05a-7aec-91ad-71a8263312a9f6TFdjHDsoS_75kmSkSOeg",
+                    "width": 600,
+                },
+                {
+                    "url": "https://example.com/019c4988-b05a-7aec-91ad-71a8263312a9z6_B4R7EMI-_75kmSkSOeg",
+                    "width": 960,
+                },
+                {
+                    "url": "https://example.com/019c4988-b05a-7aec-91ad-71a8263312a9pPd-tw4pzam_75kmSkSOeg",
+                    "width": 1280,
+                },
+                {
+                    "url": "https://example.com/019c4988-b05a-7aec-91ad-71a8263312a9kq2A0WiDvdq_75kmSkSOeg",
+                    "width": 1600,
+                },
+                {
+                    "url": "https://example.com/019c4988-b05a-7aec-91ad-71a8263312a99tA_ScAmw6e_75kmSkSOeg",
+                    "width": 1920,
+                },
+            ],
+            "backdropImage": [
+                {
+                    "url": "https://example.com/019c4988-f4c5-7632-af5f-625bc43cce77Ak38loT3hqws8y-0S2WgJw",
+                    "width": 600,
+                },
+                {
+                    "url": "https://example.com/019c4988-f4c5-7632-af5f-625bc43cce779qKNraIlnXws8y-0S2WgJw",
+                    "width": 960,
+                },
+                {
+                    "url": "https://example.com/019c4988-f4c5-7632-af5f-625bc43cce77KKQu1u0Kdaks8y-0S2WgJw",
+                    "width": 1600,
+                },
+                {
+                    "url": "https://example.com/019c4988-f4c5-7632-af5f-625bc43cce77EaJkvBz6D9As8y-0S2WgJw",
+                    "width": 1920,
+                },
+            ],
+            "squareImage": [
+                {
+                    "url": "https://example.com/019c4989-4005-7045-9820-ab1a2341c4f54nJCUvcW9IONn2DrwGgbbA",
+                    "width": 300,
+                },
+                {
+                    "url": "https://example.com/019c4989-4005-7045-9820-ab1a2341c4f50a2fCCXTediNn2DrwGgbbA",
+                    "width": 600,
+                },
+                {
+                    "url": "https://example.com/019c4989-4005-7045-9820-ab1a2341c4f5_C5tvNruZb-Nn2DrwGgbbA",
+                    "width": 960,
+                },
+                {
+                    "url": "https://example.com/019c4989-4005-7045-9820-ab1a2341c4f5WzsDjBXC9eGNn2DrwGgbbA",
+                    "width": 1280,
+                },
+                {
+                    "url": "https://example.com/019c4989-4005-7045-9820-ab1a2341c4f5A0Qyo5qct_SNn2DrwGgbbA",
+                    "width": 1600,
+                },
+            ],
+        },
+        "_embedded": {
+            "episodes": {
+                "_links": {
+                    "self": {
+                        "href": "/radio/catalog/series/series-name/episodes?page=1&pageSize=20&sort=desc"
+                    },
+                    "progresses": [
+                        {
+                            "href": "/radio/userdata/{userId}/progress/series/series-name?contentIds=H4sIAAAAAAAAA_P19g01MDMyMDAzMtXxhXFMkTkmyBxjZI4RMsfQyBQAUnyJvU0AAAA",
+                            "templated": True,
+                        }
+                    ],
+                },
+                "seriesType": "standard",
+                "_embedded": {
+                    "episodes": [
+                        {
+                            "_links": {
+                                "self": {
+                                    "href": "/radio/catalog/programs/ASDF12345678"
+                                },
+                                "playback": {
+                                    "href": "/playback/metadata/program/ASDF12345678"
+                                },
+                                "series": {
+                                    "name": "series-name",
+                                    "href": "/radio/catalog/series/series-name",
+                                    "title": "Series Title",
+                                },
+                                "season": {
+                                    "name": "202505",
+                                    "title": "Mai 2025",
+                                    "href": "/radio/catalog/series/series-name/seasons/202505",
+                                    "seriesType": "standard",
+                                },
+                                "favourite": {
+                                    "href": "/radio/userdata/{userId}/favourites/series/series-name",
+                                    "templated": True,
+                                },
+                                "share": {
+                                    "href": "https://example.com/serie/series-name/ASDF12345678"
+                                },
+                                "progress": {
+                                    "href": "/radio/userdata/{userId}/progress/programs/ASDF12345678",
+                                    "templated": True,
+                                },
+                                "recommendations": {
+                                    "href": "/radio/recommendations/ASDF12345678?list=radio_viderenavigasjon_fra_program{&maxNumber}",
+                                    "templated": True,
+                                },
+                            },
+                            "id": "019c4988-393c-724a-870a-42c0bd2450ad",
+                            "episodeId": "ASDF12345678",
+                            "titles": {
+                                "title": "Episode title",
+                                "subtitle": "Episode subtitle",
+                            },
+                            "image": [
+                                {
+                                    "url": "https://example.com/019c498a-d781-78df-a62b-bea6c5650dc8o3FUALEaZ6FUr_ro5v_InA",
+                                    "width": 300,
+                                },
+                                {
+                                    "url": "https://example.com/019c498a-d781-78df-a62b-bea6c5650dc8UGWalBA6tl5Ur_ro5v_InA",
+                                    "width": 600,
+                                },
+                                {
+                                    "url": "https://example.com/019c498a-d781-78df-a62b-bea6c5650dc8np805RQb6G5Ur_ro5v_InA",
+                                    "width": 960,
+                                },
+                                {
+                                    "url": "https://example.com/019c498a-d781-78df-a62b-bea6c5650dc8gRNnl72vGO9Ur_ro5v_InA",
+                                    "width": 1280,
+                                },
+                                {
+                                    "url": "https://example.com/019c498a-d781-78df-a62b-bea6c5650dc8hM3DuGDLR_hUr_ro5v_InA",
+                                    "width": 1600,
+                                },
+                                {
+                                    "url": "https://example.com/019c498a-d781-78df-a62b-bea6c5650dc8m2IjJ5GibV1Ur_ro5v_InA",
+                                    "width": 1920,
+                                },
+                            ],
+                            "duration": "PT57M",
+                            "date": "2025-05-01T15:03:00+02:00",
+                            "durationInSeconds": 3420,
+                            "usageRights": {
+                                "from": {
+                                    "date": "2025-05-01T15:03:00+02:00",
+                                    "displayValue": "1. mai 2025 kl. 15:03",
+                                },
+                                "to": {
+                                    "date": "2100-01-01T23:03:00+01:00",
+                                    "displayValue": "Alltid tilgjengelig",
+                                },
+                                "geoBlock": {
+                                    "isGeoBlocked": False,
+                                    "displayValue": "Verden",
+                                },
+                            },
+                            "productionYear": 2025,
+                            "availability": {"status": "available", "hasLabel": False},
+                            "contributors": [
+                                {"name": "Salma Lindgren", "role": "Programleder"},
+                                {"name": "Jacob Egeland", "role": "Programleder"},
+                                {"name": "Henrik Braaten", "role": "Medvirkende"},
+                                {"name": "Alex Borgen", "role": "Lydtekniker"},
+                                {
+                                    "name": "Mathias Sand",
+                                    "role": "Prosjektleder",
+                                },
+                            ],
+                            "badges": [],
+                        },
+                    ]
+                },
+            }
+        },
+    }
+
+
+def test_init(series_manifest):
+    series_id = "series-123"
+    manifest_url = f"/radio/catalog/series/{series_id}"
+
+    series = Series(series_id, series_manifest)
+
+    assert series.id == series_id
+    assert series.title == "Series Title"
+    assert series.manifest_url == manifest_url
+
+    assert len(series.children) == 1
+    assert isinstance(series.children[0], Season)
+    assert series.children[0].title == "Mai 2025"
+    assert (
+        series.children[0].manifest_url
+        == "/radio/catalog/series/series-name/seasons/202505"
+    )
+    assert series.children[0].thumb == None
+    assert series.children[0].fanart == None
+
+
+def test_from_url_success(series_manifest):
+    series_id = "series-123"
+    manifest_url = f"/radio/catalog/series/{series_id}"
+
+    with mock.patch("nrk.get", return_value=series_manifest) as mocked_get:
+        series = Series.from_url(f"/series/{series_id}")
+
+        mocked_get.assert_called_once_with(manifest_url)
+
+        assert series.id == series_id
+        assert series.title == "Series Title"
+        assert series.manifest_url == manifest_url
+
+        assert len(series.children) == 1
+
+
+def test_from_url_wrong_format():
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        _ = Series.from_url("/radio/series/series-123")

--- a/tests/test_seriesplug.py
+++ b/tests/test_seriesplug.py
@@ -1,0 +1,116 @@
+import pytest
+
+from nrkradio import SeriesPlug
+
+
+@pytest.fixture
+def series_plug_response():
+    return {
+        "type": "series",
+        "_links": {"series": "/series/seriesname"},
+        "series": {
+            "titles": {
+                "title": "Series title",
+                "subtitle": "Series subtitle",
+            },
+            "image": {
+                "id": "019c39ea-f0b7-7463-9aa3-9b63639053ec",
+                "webImages": [
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecPMwQEKDdQrtaBbEZIzo36w",
+                        "width": 300,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecQpyYH7B0NsZaBbEZIzo36w",
+                        "width": 600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053eccDtEveYObMJaBbEZIzo36w",
+                        "width": 960,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ec1EaKbUK3LLNaBbEZIzo36w",
+                        "width": 1280,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053eczZtNkmL5zmZaBbEZIzo36w",
+                        "width": 1600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecmkrwoQ1iInxaBbEZIzo36w",
+                        "width": 1920,
+                    },
+                ],
+            },
+            "numberOfEpisodes": 1,
+        },
+    }
+
+
+@pytest.fixture
+def series_plug_only_subtitle_response():
+    return {
+        "type": "series",
+        "_links": {"series": "/series/seriesname"},
+        "series": {
+            "titles": {
+                "subtitle": "Series subtitle",
+            },
+            "image": {
+                "id": "019c39ea-f0b7-7463-9aa3-9b63639053ec",
+                "webImages": [
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecPMwQEKDdQrtaBbEZIzo36w",
+                        "width": 300,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecQpyYH7B0NsZaBbEZIzo36w",
+                        "width": 600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053eccDtEveYObMJaBbEZIzo36w",
+                        "width": 960,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ec1EaKbUK3LLNaBbEZIzo36w",
+                        "width": 1280,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053eczZtNkmL5zmZaBbEZIzo36w",
+                        "width": 1600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecmkrwoQ1iInxaBbEZIzo36w",
+                        "width": 1920,
+                    },
+                ],
+            },
+            "numberOfEpisodes": 1,
+        },
+    }
+
+
+def test_init(series_plug_response):
+
+    series_plug: SeriesPlug = SeriesPlug(series_plug_response)
+
+    assert series_plug.id == None
+    assert series_plug.title == "Series title: Series subtitle"
+    assert series_plug.manifest_url == "/series/seriesname"
+    assert (
+        series_plug.thumb
+        == "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecPMwQEKDdQrtaBbEZIzo36w"
+    )
+    assert (
+        series_plug.fanart
+        == "https://example.com/019c39ea-f0b7-7463-9aa3-9b63639053ecmkrwoQ1iInxaBbEZIzo36w"
+    )
+
+
+def test_init_only_subtitle(series_plug_only_subtitle_response):
+
+    series_plug: SeriesPlug = SeriesPlug(series_plug_only_subtitle_response)
+
+    assert series_plug.id == None
+    assert series_plug.title == "Series subtitle"
+    assert series_plug.manifest_url == "/series/seriesname"

--- a/tests/test_standaloneprogram.py
+++ b/tests/test_standaloneprogram.py
@@ -1,0 +1,178 @@
+from unittest import mock
+import pytest
+
+from nrkradio import StandaloneProgram
+
+
+@pytest.fixture
+def standalone_program_manifest():
+    return {
+        "_links": {
+            "self": {"href": "/playback/manifest/program/QWERT12345678"},
+            "metadata": {
+                "href": "/playback/metadata/program/QWERT12345678",
+                "name": "metadata",
+            },
+        },
+        "id": "QWERT12345678",
+        "playability": "playable",
+        "streamingMode": "onDemand",
+        "availability": {
+            "information": "",
+            "isGeoBlocked": False,
+            "onDemand": {
+                "from": "2026-02-05T06:00:00+01:00",
+                "to": "2100-01-01T23:59:59+01:00",
+                "hasRightsNow": True,
+            },
+            "live": None,
+            "externalEmbeddingAllowed": True,
+        },
+        "statistics": {
+            "scores": {
+                "springStreamSite": "nrkradio",
+                "springStreamStream": "programspiller/odm/nrk_online/drama/program-title/s01e01.program-title.QWERT12345678",
+                "springStreamContentType": "other/generic_hls",
+                "springStreamProgramId": "QWERT12345678",
+                "springStreamDuration": 764,
+            },
+            "ga": {
+                "dimension1": "prf:QWERT12345678",
+                "dimension2": "program-title",
+                "dimension3": "2008",
+                "dimension4": "01",
+                "dimension5": "01",
+                "dimension10": "prf:QWERT12345678",
+                "dimension21": "program-title",
+                "dimension22": "1",
+                "dimension23": "drama",
+                "dimension25": "audio",
+                "dimension26": "ondemand",
+                "dimension29": "other/generic_hls",
+                "dimension36": "other-generichls|notapplicable|none|ondemand|world|akamai-cdn|europeaneconomicarea|notapplicable|none|notapplicable",
+            },
+            "conviva": None,
+            "luna": {
+                "config": {
+                    "beacon": "https://some-none-existing-alias.example.com/akamai-beacon.xml"
+                },
+                "data": {
+                    "title": "",
+                    "device": "",
+                    "playerId": "",
+                    "deliveryType": "",
+                    "playerInfo": "",
+                    "cdnName": "Akamai-Cdn",
+                },
+            },
+            "qualityOfExperience": {
+                "mediaId": "QWERT12345678",
+                "title": "Program Title: 1. episode",
+                "clientName": "other-generichls",
+                "cdnName": "akamai-cdn",
+                "npawCdnName": "AKAMAI",
+                "streamingFormat": "hlsv3",
+                "segmentLength": "notapplicable",
+                "assetType": "ondemand",
+                "correlationId": "0d91c871e930b00ff64b2ed85c1b08d6",
+                "live": False,
+                "npawCustomDimensions": {
+                    "1": "other-generichls",
+                    "2": "0d91c871e930b00ff64b2ed85c1b08d6",
+                },
+            },
+            "snowplow": {"source": "prf"},
+            "kantar": {
+                "trackingType": "onDemand",
+                "site": "nrkradio",
+                "contentType": "other/generic_hls",
+                "stream": "programspiller/odm/nrk_online/drama/program-title/s01e01.program-title.QWERT12345678",
+                "duration": 764,
+                "contentId": "QWERT12345678",
+            },
+        },
+        "playable": {
+            "endSequenceStartTime": None,
+            "duration": "PT12M44S",
+            "assets": [
+                {
+                    "url": "https://example.com/open/ps/mktt/QWERT12345678/6882926e-2.smil/muxed.m3u8?adap=audio&aco=aac",
+                    "format": "HLS",
+                    "mimeType": "application/vnd.apple.mpegurl",
+                    "encrypted": False,
+                    "encryptionScheme": "none",
+                }
+            ],
+            "liveBuffer": None,
+            "subtitles": [],
+            "thumbnails": [],
+        },
+        "nonPlayable": None,
+        "displayAspectRatio": None,
+        "sourceMedium": "audio",
+    }
+
+
+def test_init():
+    title = "Dummy title"
+    program_id = "ABCD123456789"
+    standalone_program = StandaloneProgram(title, program_id, [])
+    assert standalone_program.id == program_id
+    assert standalone_program.title == title
+    assert standalone_program.manifest_url == f"/playback/manifest/program/{program_id}"
+    assert standalone_program.thumb == None
+    assert standalone_program.fanart == None
+
+def test_from_url_from_season_success():
+
+    program_id = "ABCDEF12345678"
+    standalone_program: StandaloneProgram = StandaloneProgram.from_url(
+        f"/playback/manifest/program/{program_id}"
+    )
+
+    assert standalone_program.id == program_id
+    assert standalone_program.manifest_url == f"/playback/manifest/program/{program_id}"
+
+
+def test_from_url_from_plug_success():
+
+    program_id = "ABCDEF12345678"
+    standalone_program: StandaloneProgram = StandaloneProgram.from_url(
+        f"/programs/{program_id}"
+    )
+
+    assert standalone_program.id == program_id
+    assert standalone_program.manifest_url == f"/playback/manifest/program/{program_id}"
+
+
+def test_from_url_wrong_format():
+    with pytest.raises(ValueError, match="Wrong format of url"):
+        StandaloneProgram.from_url("/ABCDEFG1234567")
+
+
+def test_get_media_url(standalone_program_manifest):
+    with mock.patch("nrk.get", return_value=standalone_program_manifest) as mocked_get:
+        program_id = "QWERT12345678"
+        standalone_program = StandaloneProgram("Dummy title", program_id, [])
+
+        assert (
+            standalone_program.media_url
+            == "https://example.com/open/ps/mktt/QWERT12345678/6882926e-2.smil/muxed.m3u8?adap=audio&aco=aac"
+        )
+
+        mocked_get.assert_called_once_with(f"/playback/manifest/program/{program_id}")
+
+
+def test_get_media_url_multiple_calls(standalone_program_manifest):
+    with mock.patch("nrk.get", return_value=standalone_program_manifest) as mocked_get:
+        program_id = "QWERT12345678"
+        standalone_program = StandaloneProgram("Dummy title", program_id, [])
+
+        assert (
+            standalone_program.media_url
+            == "https://example.com/open/ps/mktt/QWERT12345678/6882926e-2.smil/muxed.m3u8?adap=audio&aco=aac"
+        )
+        _ = standalone_program.media_url
+        _ = standalone_program.media_url
+        _ = standalone_program.media_url
+        mocked_get.assert_called_once_with(f"/playback/manifest/program/{program_id}")

--- a/tests/test_standaloneprogramplug.py
+++ b/tests/test_standaloneprogramplug.py
@@ -1,0 +1,134 @@
+import pytest
+
+from nrkradio import StandaloneProgramPlug
+
+
+@pytest.fixture
+def standaloneprogram_plug_response():
+    return {
+        "type": "standaloneProgram",
+        "_links": {
+            "program": "/programs/ABCDE12345678",
+            "mediaelement": "/mediaelement/ABCDE12345678",
+        },
+        "program": {
+            "titles": {
+                "title": "Program Title",
+                "subtitle": "Program subtitle",
+            },
+            "image": {
+                "id": "019c39dd-ab7a-7a8f-8e17-4ddabd55f683",
+                "webImages": [
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683_yDO3z4Ntptdhmb3_Ub0iQ",
+                        "width": 300,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683rLa_uVTOE_pdhmb3_Ub0iQ",
+                        "width": 600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683GlIIpPHIX9Rdhmb3_Ub0iQ",
+                        "width": 960,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683gl23UWjOJA5dhmb3_Ub0iQ",
+                        "width": 1280,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683Illh5pIabwNdhmb3_Ub0iQ",
+                        "width": 1600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f6831ilEZT80k3tdhmb3_Ub0iQ",
+                        "width": 1920,
+                    },
+                ],
+            },
+            "duration": "PT0S",
+        },
+    }
+
+
+@pytest.fixture
+def standaloneprogram_plug_only_subtitle_response():
+    return {
+        "type": "standaloneProgram",
+        "_links": {
+            "program": "/programs/ABCDE12345678",
+            "mediaelement": "/mediaelement/ABCDE12345678",
+        },
+        "program": {
+            "titles": {
+                "subtitle": "Program subtitle",
+            },
+            "image": {
+                "id": "019c39dd-ab7a-7a8f-8e17-4ddabd55f683",
+                "webImages": [
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683_yDO3z4Ntptdhmb3_Ub0iQ",
+                        "width": 300,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683rLa_uVTOE_pdhmb3_Ub0iQ",
+                        "width": 600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683GlIIpPHIX9Rdhmb3_Ub0iQ",
+                        "width": 960,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683gl23UWjOJA5dhmb3_Ub0iQ",
+                        "width": 1280,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683Illh5pIabwNdhmb3_Ub0iQ",
+                        "width": 1600,
+                    },
+                    {
+                        "uri": "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f6831ilEZT80k3tdhmb3_Ub0iQ",
+                        "width": 1920,
+                    },
+                ],
+            },
+            "duration": "PT0S",
+        },
+    }
+
+
+def test_init(standaloneprogram_plug_response):
+
+    standaloneprogram_plug: StandaloneProgramPlug = StandaloneProgramPlug(
+        standaloneprogram_plug_response
+    )
+
+    assert standaloneprogram_plug.id == None
+    assert standaloneprogram_plug.title == "Program Title: Program subtitle"
+    assert standaloneprogram_plug.manifest_url == "/programs/ABCDE12345678"
+    assert (
+        standaloneprogram_plug.thumb
+        == "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683_yDO3z4Ntptdhmb3_Ub0iQ"
+    )
+    assert (
+        standaloneprogram_plug.fanart
+        == "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f6831ilEZT80k3tdhmb3_Ub0iQ"
+    )
+
+
+def test_init_only_subtitle(standaloneprogram_plug_only_subtitle_response):
+
+    standaloneprogram_plug: StandaloneProgramPlug = StandaloneProgramPlug(
+        standaloneprogram_plug_only_subtitle_response
+    )
+
+    assert standaloneprogram_plug.id == None
+    assert standaloneprogram_plug.title == "Program subtitle"
+    assert standaloneprogram_plug.manifest_url == "/programs/ABCDE12345678"
+    assert (
+        standaloneprogram_plug.thumb
+        == "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f683_yDO3z4Ntptdhmb3_Ub0iQ"
+    )
+    assert (
+        standaloneprogram_plug.fanart
+        == "https://example.com/019c39dd-ab7a-7a8f-8e17-4ddabd55f6831ilEZT80k3tdhmb3_Ub0iQ"
+    )


### PR DESCRIPTION
Closes #46

Adds a category menu item for radio on-demand programs using the pages API.
I tried to minimize the number of requests per menu item to avoid long waiting times we see with the TV items.

I'd any appreciate feedback before I merge the changes, especially regarding whether they work on LibreELEC.